### PR TITLE
Added operator-config yaml schema linter

### DIFF
--- a/package.json
+++ b/package.json
@@ -247,8 +247,15 @@
           "group": "inline"
         }
       ]
-    }
+    },
+    "yamlValidation": [
+      {
+        "fileMatch": "operator-config.yaml",
+        "url": "./resources/schema/operator-config.schema.json"
+      }
+    ]
   },
+  "extensionDependencies": ["redhat.vscode-yaml"],
   "scripts": {
     "vscode:prepublish": "npm run package",
     "webpack": "npm run clean && npm run compile && webpack --mode development",

--- a/resources/schema/operator-config.schema.json
+++ b/resources/schema/operator-config.schema.json
@@ -1,0 +1,462 @@
+{
+	"$schema": "https://json-schema.org/draft/2020-12/schema",
+	"$id": "https://github.ibm.com/zoscb/common/apis/zoscb/v2beta2/operator-config",
+	"$ref": "#/$defs/OperatorConfig",
+	"$defs": {
+		"AggregationRule": {
+			"properties": {
+				"clusterRoleSelectors": {
+					"items": {
+						"$ref": "#/$defs/LabelSelector"
+					},
+					"type": "array"
+				}
+			},
+			"additionalProperties": false,
+			"type": "object"
+		},
+		"ClusterRole": {
+			"properties": {
+				"kind": {
+					"type": "string"
+				},
+				"apiVersion": {
+					"type": "string"
+				},
+				"metadata": {
+					"$ref": "#/$defs/ObjectMeta"
+				},
+				"rules": {
+					"items": {
+						"$ref": "#/$defs/PolicyRule"
+					},
+					"type": "array"
+				},
+				"aggregationRule": {
+					"$ref": "#/$defs/AggregationRule"
+				}
+			},
+			"additionalProperties": false,
+			"type": "object",
+			"required": [
+				"rules"
+			]
+		},
+		"FieldsV1": {
+			"properties": {},
+			"additionalProperties": false,
+			"type": "object"
+		},
+		"IconData": {
+			"properties": {
+				"base64data": {
+					"type": "string"
+				},
+				"mediatype": {
+					"type": "string"
+				}
+			},
+			"additionalProperties": false,
+			"type": "object"
+		},
+		"LabelSelector": {
+			"properties": {
+				"matchLabels": {
+					"patternProperties": {
+						".*": {
+							"type": "string"
+						}
+					},
+					"type": "object"
+				},
+				"matchExpressions": {
+					"items": {
+						"$ref": "#/$defs/LabelSelectorRequirement"
+					},
+					"type": "array"
+				}
+			},
+			"additionalProperties": false,
+			"type": "object"
+		},
+		"LabelSelectorRequirement": {
+			"properties": {
+				"key": {
+					"type": "string"
+				},
+				"operator": {
+					"type": "string"
+				},
+				"values": {
+					"items": {
+						"type": "string"
+					},
+					"type": "array"
+				}
+			},
+			"additionalProperties": false,
+			"type": "object",
+			"required": [
+				"key",
+				"operator"
+			]
+		},
+		"ManagedFieldsEntry": {
+			"properties": {
+				"manager": {
+					"type": "string"
+				},
+				"operation": {
+					"type": "string"
+				},
+				"apiVersion": {
+					"type": "string"
+				},
+				"time": {
+					"$ref": "#/$defs/Time"
+				},
+				"fieldsType": {
+					"type": "string"
+				},
+				"fieldsV1": {
+					"$ref": "#/$defs/FieldsV1"
+				},
+				"subresource": {
+					"type": "string"
+				}
+			},
+			"additionalProperties": false,
+			"type": "object"
+		},
+		"ObjectMeta": {
+			"properties": {
+				"name": {
+					"type": "string"
+				},
+				"generateName": {
+					"type": "string"
+				},
+				"namespace": {
+					"type": "string"
+				},
+				"selfLink": {
+					"type": "string"
+				},
+				"uid": {
+					"type": "string"
+				},
+				"resourceVersion": {
+					"type": "string"
+				},
+				"generation": {
+					"type": "integer"
+				},
+				"creationTimestamp": {
+					"$ref": "#/$defs/Time"
+				},
+				"deletionTimestamp": {
+					"$ref": "#/$defs/Time"
+				},
+				"deletionGracePeriodSeconds": {
+					"type": "integer"
+				},
+				"labels": {
+					"patternProperties": {
+						".*": {
+							"type": "string"
+						}
+					},
+					"type": "object"
+				},
+				"annotations": {
+					"patternProperties": {
+						".*": {
+							"type": "string"
+						}
+					},
+					"type": "object"
+				},
+				"ownerReferences": {
+					"items": {
+						"$ref": "#/$defs/OwnerReference"
+					},
+					"type": "array"
+				},
+				"finalizers": {
+					"items": {
+						"type": "string"
+					},
+					"type": "array"
+				},
+				"managedFields": {
+					"items": {
+						"$ref": "#/$defs/ManagedFieldsEntry"
+					},
+					"type": "array"
+				}
+			},
+			"additionalProperties": false,
+			"type": "object"
+		},
+		"ObjectVariables": {
+			"properties": {
+				"name": {
+					"type": "string"
+				},
+				"description": {
+					"type": "string"
+				},
+				"displayName": {
+					"type": "string"
+				},
+				"type": {
+					"type": "string"
+				},
+				"kindReference": {
+					"type": "string"
+				},
+				"default": {
+					"type": "string"
+				},
+				"options": {
+					"items": {
+						"type": "string"
+					},
+					"type": "array"
+				},
+				"required": {
+					"type": "boolean"
+				}
+			},
+			"additionalProperties": false,
+			"type": "object"
+		},
+		"OperatorConfig": {
+			"properties": {
+				"description": {
+					"type": "string"
+				},
+				"displayName": {
+					"type": "string"
+				},
+				"domain": {
+					"type": "string"
+				},
+				"name": {
+					"type": "string"
+				},
+				"provider": {
+					"type": "string"
+				},
+				"migrationPlaybook": {
+					"type": "string"
+				},
+				"resources": {
+					"items": {
+						"$ref": "#/$defs/OperatorResource"
+					},
+					"type": "array"
+				},
+				"version": {
+					"type": "string"
+				},
+				"icon": {
+					"items": {
+						"$ref": "#/$defs/IconData"
+					},
+					"type": "array"
+				},
+				"replaces": {
+					"type": "string"
+				},
+				"collectionPath": {
+					"type": "string"
+				},
+				"roles": {
+					"items": {
+						"$ref": "#/$defs/Role"
+					},
+					"type": "array"
+				},
+				"clusterRoles": {
+					"items": {
+						"$ref": "#/$defs/ClusterRole"
+					},
+					"type": "array"
+				}
+			},
+			"additionalProperties": false,
+			"type": "object"
+		},
+		"OperatorResource": {
+			"properties": {
+				"description": {
+					"type": "string"
+				},
+				"displayName": {
+					"type": "string"
+				},
+				"kind": {
+					"type": "string"
+				},
+				"playbook": {
+					"type": "string"
+				},
+				"vars": {
+					"items": {
+						"$ref": "#/$defs/ResourceVariable"
+					},
+					"type": "array"
+				},
+				"finalizer": {
+					"type": "string"
+				},
+				"hideResource": {
+					"type": "boolean"
+				}
+			},
+			"additionalProperties": false,
+			"type": "object"
+		},
+		"OwnerReference": {
+			"properties": {
+				"apiVersion": {
+					"type": "string"
+				},
+				"kind": {
+					"type": "string"
+				},
+				"name": {
+					"type": "string"
+				},
+				"uid": {
+					"type": "string"
+				},
+				"controller": {
+					"type": "boolean"
+				},
+				"blockOwnerDeletion": {
+					"type": "boolean"
+				}
+			},
+			"additionalProperties": false,
+			"type": "object",
+			"required": [
+				"apiVersion",
+				"kind",
+				"name",
+				"uid"
+			]
+		},
+		"PolicyRule": {
+			"properties": {
+				"verbs": {
+					"items": {
+						"type": "string"
+					},
+					"type": "array"
+				},
+				"apiGroups": {
+					"items": {
+						"type": "string"
+					},
+					"type": "array"
+				},
+				"resources": {
+					"items": {
+						"type": "string"
+					},
+					"type": "array"
+				},
+				"resourceNames": {
+					"items": {
+						"type": "string"
+					},
+					"type": "array"
+				},
+				"nonResourceURLs": {
+					"items": {
+						"type": "string"
+					},
+					"type": "array"
+				}
+			},
+			"additionalProperties": false,
+			"type": "object",
+			"required": [
+				"verbs"
+			]
+		},
+		"ResourceVariable": {
+			"properties": {
+				"name": {
+					"type": "string"
+				},
+				"description": {
+					"type": "string"
+				},
+				"displayName": {
+					"type": "string"
+				},
+				"type": {
+					"type": "string"
+				},
+				"kindReference": {
+					"type": "string"
+				},
+				"default": {
+					"type": "string"
+				},
+				"options": {
+					"items": {
+						"type": "string"
+					},
+					"type": "array"
+				},
+				"required": {
+					"type": "boolean"
+				},
+				"objectVariables": {
+					"items": {
+						"$ref": "#/$defs/ObjectVariables"
+					},
+					"type": "array"
+				},
+				"array": {
+					"type": "boolean"
+				}
+			},
+			"additionalProperties": false,
+			"type": "object"
+		},
+		"Role": {
+			"properties": {
+				"kind": {
+					"type": "string"
+				},
+				"apiVersion": {
+					"type": "string"
+				},
+				"metadata": {
+					"$ref": "#/$defs/ObjectMeta"
+				},
+				"rules": {
+					"items": {
+						"$ref": "#/$defs/PolicyRule"
+					},
+					"type": "array"
+				}
+			},
+			"additionalProperties": false,
+			"type": "object",
+			"required": [
+				"rules"
+			]
+		},
+		"Time": {
+			"properties": {},
+			"additionalProperties": false,
+			"type": "object"
+		}
+	}
+}


### PR DESCRIPTION
Added operator-config.yaml linting based on the vscode-yaml extension: https://github.com/redhat-developer/vscode-yaml#mapping-a-schema-in-an-extension 