### PR TITLE
Display logs as virtual documents

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -69,7 +69,6 @@ export async function activate(context: vscode.ExtensionContext) {
 	context.subscriptions.push(executeSimpleSdkCommand(VSCodeCommands.redeployOperator, outputChannel));
 	context.subscriptions.push(deleteCustomResource(VSCodeCommands.deleteCustomResource, k8s));
 	context.subscriptions.push(executeContainerLogDownloadCommand(VSCodeCommands.downloadLogs, k8s));
-	context.subscriptions.push(executeContainerLogDownloadCommand(VSCodeCommands.followLogs, k8s));
 	context.subscriptions.push(executeContainerLogDownloadCommand(VSCodeCommands.downloadVerboseLogs, k8s));
 	context.subscriptions.push(executeOpenLinkCommand(VSCodeCommands.openEditLink));
 	context.subscriptions.push(executeOpenLinkCommand(VSCodeCommands.openAddLink));
@@ -178,12 +177,6 @@ function executeContainerLogDownloadCommand(command: string, k8s: KubernetesObj)
 				switch(command) {
 					case VSCodeCommands.downloadLogs: {
 						const logUri = util.buildContainerLogUri(containerItemArgs.podObj.metadata?.name!, containerItemArgs.containerStatus.name);
-						const doc = await vscode.workspace.openTextDocument(logUri);
-						await vscode.window.showTextDocument(doc, {preview: false});
-						break;
-					}
-					case VSCodeCommands.followLogs: {
-						const logUri = util.buildContainerLogUri(containerItemArgs.podObj.metadata?.name!, containerItemArgs.containerStatus.name, true);
 						const doc = await vscode.workspace.openTextDocument(logUri);
 						await vscode.window.showTextDocument(doc, {preview: false});
 						break;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -54,7 +54,7 @@ export async function activate(context: vscode.ExtensionContext) {
 	vscode.window.registerTreeDataProvider(VSCodeViewIds.help, linksTreeProvider);
 	vscode.window.registerTreeDataProvider(VSCodeViewIds.openshiftClusterInfo, openshiftTreeProvider);
 	vscode.workspace.registerTextDocumentContentProvider(util.logScheme, containerLogProvider);
-	vscode.workspace.registerTextDocumentContentProvider(util.verboseLogScheme, containerLogProvider);
+	vscode.workspace.registerTextDocumentContentProvider(util.verboseLogScheme, verboseContainerLogProvider);
 
 	
 	// Register Comands
@@ -114,7 +114,7 @@ function installOcSdk(command: string, ocSdkCmd: OcSdkCommand, session: Session,
 	});
 }
 
-function updateProject(command: string, ocCmd: OcCommand): vscode.Disposable {
+function updateProject(command: string, ocCmd: OcCommand, outputChannel?: vscode.OutputChannel): vscode.Disposable {
 	return vscode.commands.registerCommand(command, async (namespaceArg?: string, logPath?: string) => {
 		let namespace: string | undefined;
 		if (namespaceArg) {
@@ -123,7 +123,7 @@ function updateProject(command: string, ocCmd: OcCommand): vscode.Disposable {
 			namespace = await util.generateProjectDropDown();
 		}
 		if (namespace) {
-			ocCmd.runOcProjectCommand(namespace, logPath).then(() => {
+			ocCmd.runOcProjectCommand(namespace, outputChannel, logPath).then(() => {
 				vscode.window.showInformationMessage("Successfully updating Project on OpenShift cluster");
 				vscode.commands.executeCommand(VSCodeCommands.refreshAll);
 			}).catch((e) => {
@@ -133,7 +133,7 @@ function updateProject(command: string, ocCmd: OcCommand): vscode.Disposable {
 	});
 }
 
-function logIn(command: string, ocCmd: OcCommand, session: Session): vscode.Disposable {
+function logIn(command: string, ocCmd: OcCommand, session: Session, outputChannel?: vscode.OutputChannel): vscode.Disposable {
 	return vscode.commands.registerCommand(command, async (params?: string[], logPath?: string) => {
 		let args: string[] | undefined = [];
 		if (params === undefined || params?.length === 0) {
@@ -142,7 +142,7 @@ function logIn(command: string, ocCmd: OcCommand, session: Session): vscode.Disp
 			args = params;
 		}
 		if (args) {
-			ocCmd.runOcLoginCommand(args, logPath).then(() => {
+			ocCmd.runOcLoginCommand(args, outputChannel, logPath).then(() => {
 				session.loggedIntoOpenShift = true;
 				vscode.window.showInformationMessage("Successfully logged into OpenShift cluster");
 				vscode.commands.executeCommand(VSCodeCommands.refreshAll);

--- a/src/kubernetes/kubernetes.ts
+++ b/src/kubernetes/kubernetes.ts
@@ -152,21 +152,9 @@ export class KubernetesObj extends KubernetesContext {
      * @param workspacePath - The current workspace path
      * @returns - A promise containing the path to the container log
      */
-    public async downloadContainerLogs(podName: string, containerName: string, workspacePath: string): Promise<string | undefined> {
-        return this.coreV1Api.readNamespacedPodLog(podName, this.namespace, containerName).then((res) => {
-            if (! fs.existsSync(path.join(workspacePath, ".openshiftLogs"))) {
-                fs.mkdirSync(path.join(workspacePath, ".openshiftLogs"));
-            }
-            const logsPath = path.join(workspacePath, ".openshiftLogs", `${podName}-${containerName}.log`);
-            try {
-                fs.writeFileSync(logsPath, Buffer.from(res.body));
-            } catch (e) {
-                const msg = `Failure downloading container logs. ${e}`;
-                console.error(msg);
-                vscode.window.showErrorMessage(msg);
-                return undefined;
-            }
-            return logsPath;
+    public async downloadContainerLogs(podName: string, containerName: string, follow?: boolean): Promise<string | undefined> {
+        return this.coreV1Api.readNamespacedPodLog(podName, this.namespace, containerName, follow).then((res) => {
+            return res.body;
         }).catch((e) => {
             const msg = `Failure retrieving Pod logs. ${JSON.stringify(e)}`;
             console.error(msg);
@@ -179,22 +167,17 @@ export class KubernetesObj extends KubernetesContext {
      * Download the verbose container logs
      * @param podName - The pod name where the container resides
      * @param containerName - The container name within the pod
-     * @param workspacePath - The current workspace path
      * @param apiVersion - The resource API version
      * @param kind - The resource Kind
      * @param instanceName - The resource instance name
      * @returns - A promise containing the path to the container log
      */
-    public async downloadVerboseContainerLogs(podName: string, containerName: string, workspacePath: string, apiVersion: string, kind: string, instanceName: string, logPath?: string): Promise<string | undefined> {
-        if (! fs.existsSync(path.join(workspacePath, ".openshiftLogs"))) {
-            fs.mkdirSync(path.join(workspacePath, ".openshiftLogs"));
-        }
-        const openshiftLogsPath = path.join(workspacePath, ".openshiftLogs", `${podName}-${containerName}-verbose.log`);
+    public async downloadVerboseContainerLogs(podName: string, containerName: string, apiVersion: string, kind: string, instanceName: string, logPath?: string): Promise<string | undefined> {
         const ocCmd = new OcCommand();
-        return ocCmd.runOcCpCommand(podName, this.namespace, containerName, openshiftLogsPath, apiVersion, kind, instanceName, logPath).then(() => {
-            return openshiftLogsPath;
+        return ocCmd.runOcExecCommand(podName, this.namespace, containerName, apiVersion, kind, instanceName, logPath).then((data) => {
+            return data;
         }).catch((e) => {
-            const msg = `Failure running the "oc cp" command. ${e.response.statusMessage}`;
+            const msg = `Failure running the "oc exec" command. ${e.response.statusMessage}`;
             console.error(msg);
             vscode.window.showErrorMessage(msg);
             return undefined;

--- a/src/kubernetes/kubernetes.ts
+++ b/src/kubernetes/kubernetes.ts
@@ -152,8 +152,8 @@ export class KubernetesObj extends KubernetesContext {
      * @param workspacePath - The current workspace path
      * @returns - A promise containing the path to the container log
      */
-    public async downloadContainerLogs(podName: string, containerName: string, follow?: boolean): Promise<string | undefined> {
-        return this.coreV1Api.readNamespacedPodLog(podName, this.namespace, containerName, follow).then((res) => {
+    public async downloadContainerLogs(podName: string, containerName: string): Promise<string | undefined> {
+        return this.coreV1Api.readNamespacedPodLog(podName, this.namespace, containerName).then((res) => {
             return res.body;
         }).catch((e) => {
             const msg = `Failure retrieving Pod logs. ${JSON.stringify(e)}`;

--- a/src/kubernetes/kubernetes.ts
+++ b/src/kubernetes/kubernetes.ts
@@ -170,11 +170,13 @@ export class KubernetesObj extends KubernetesContext {
      * @param apiVersion - The resource API version
      * @param kind - The resource Kind
      * @param instanceName - The resource instance name
+     * @param outputChannel - The VS Code output channel to display command output
+     * @param logPath - Log path to store command output
      * @returns - A promise containing the path to the container log
      */
-    public async downloadVerboseContainerLogs(podName: string, containerName: string, apiVersion: string, kind: string, instanceName: string, logPath?: string): Promise<string | undefined> {
+    public async downloadVerboseContainerLogs(podName: string, containerName: string, apiVersion: string, kind: string, instanceName: string, outputChannel?: vscode.OutputChannel, logPath?: string): Promise<string | undefined> {
         const ocCmd = new OcCommand();
-        return ocCmd.runOcExecCommand(podName, this.namespace, containerName, apiVersion, kind, instanceName, logPath).then((data) => {
+        return ocCmd.runOcExecCommand(podName, this.namespace, containerName, apiVersion, kind, instanceName, outputChannel, logPath).then((data) => {
             return data;
         }).catch((e) => {
             const msg = `Failure running the "oc exec" command. ${e.response.statusMessage}`;

--- a/src/shellCommands/ocCommand.ts
+++ b/src/shellCommands/ocCommand.ts
@@ -3,18 +3,19 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import * as vscode from 'vscode';
 import * as child_process from 'child_process';
-import { resolve4 } from 'dns/promises';
 import * as fs from 'fs-extra';
 
 export class OcCommand {
     /**
      * Executes the requested command
      * @param args - The arguments to pass to the command
+     * @param outputChannel - The VS Code output channel to display command output
      * @param logPath - Log path to store command output
      * @returns - A Promise containing the the return code of the executed command
      */
-     private async run(args?: Array<string>, logPath?: string): Promise<any> {
+     private async run(args?: Array<string>, outputChannel?: vscode.OutputChannel, logPath?: string): Promise<any> {
         const options: | child_process.SpawnOptions = {
             env: process.env,
             shell: true,
@@ -36,17 +37,17 @@ export class OcCommand {
 
         let output: string="";
         childProcess.stdout?.on('data', data => {
-            console.log(`${data}`);
+            outputChannel?.appendLine(data);
             output = output.concat(data);
         });
         childProcess.stderr?.on('data', data => {
-            console.error(`${data}`);
+            outputChannel?.appendLine(data);
             output = output.concat(data);
         });
 
         return new Promise<string>((resolve: any, reject: any) => {
             childProcess.on('error', (error: Error) => {
-                console.error(error.message);
+                outputChannel?.appendLine(error.message);
                 return reject(error.message);
             });
             childProcess.on('close', (code: number) => {
@@ -73,7 +74,7 @@ export class OcCommand {
      * @param instanceName 
      * @returns 
      */
-     async runOcExecCommand(podName: string, namespace: string,containerName: string, apiVersion: string, kind: string, instanceName: string, logPath?: string): Promise<any> {
+     async runOcExecCommand(podName: string, namespace: string,containerName: string, apiVersion: string, kind: string, instanceName: string, outputChannel?: vscode.OutputChannel, logPath?: string): Promise<any> {
         const args: Array<string> = [
             "exec",
             podName,
@@ -83,7 +84,7 @@ export class OcCommand {
             "cat",
             `/tmp/ansible-operator/runner/suboperator.zoscb.ibm.com/${apiVersion}/${kind}/${namespace}/${instanceName}/artifacts/latest/stdout`
         ];
-        return this.run(args, logPath);
+        return this.run(args, outputChannel, logPath);
     }
 
     /**
@@ -97,7 +98,7 @@ export class OcCommand {
      * @param instanceName 
      * @returns 
      */
-    async runOcCpCommand(podName: string, namespace: string,containerName: string, workspacePath: string, apiVersion: string, kind: string, instanceName: string, logPath?: string): Promise<any> {
+    async runOcCpCommand(podName: string, namespace: string,containerName: string, workspacePath: string, apiVersion: string, kind: string, instanceName: string, outputChannel?: vscode.OutputChannel, logPath?: string): Promise<any> {
         const args: Array<string> = [
             "cp",
             `${namespace}/${podName}:/tmp/ansible-operator/runner/suboperator.zoscb.ibm.com/${apiVersion}/${kind}/${namespace}/${instanceName}/artifacts/latest/stdout`,
@@ -105,7 +106,7 @@ export class OcCommand {
             "-c",
             containerName
         ];
-        return this.run(args, logPath);
+        return this.run(args, outputChannel, logPath);
     }
 
     /**
@@ -114,10 +115,10 @@ export class OcCommand {
      * @param token 
      * @returns 
      */
-    async runOcLoginCommand(args: Array<string>, logPath?: string): Promise<any> {
+    async runOcLoginCommand(args: Array<string>, outputChannel?: vscode.OutputChannel, logPath?: string): Promise<any> {
         const logInArg: Array<string> = ["login"];
         const finalArgs = logInArg.concat(args);
-        return this.run(finalArgs, logPath);
+        return this.run(finalArgs, outputChannel, logPath);
     }
 
     /**
@@ -126,8 +127,8 @@ export class OcCommand {
      * @param token 
      * @returns 
      */
-    async runOcProjectCommand(project: string, logPath?: string): Promise<any> {
+    async runOcProjectCommand(project: string, outputChannel?: vscode.OutputChannel, logPath?: string): Promise<any> {
         const args: Array<string> = ["project", project];
-        return this.run(args, logPath);
+        return this.run(args, outputChannel, logPath);
     }
 }

--- a/src/shellCommands/ocSdkCommands.ts
+++ b/src/shellCommands/ocSdkCommands.ts
@@ -6,7 +6,6 @@
 import * as vscode from 'vscode';
 import * as child_process from 'child_process';
 import * as fs from 'fs-extra';
-import * as path from 'path';
 
 export class OcSdkCommand {
     constructor(private pwd?: string | undefined) {}
@@ -53,7 +52,6 @@ export class OcSdkCommand {
 
         return new Promise<string>((resolve: any, reject: any) => {
             childProcess.on('error', (error: Error) => {
-                console.log(error.message);
                 outputChannel?.appendLine(error.message);
                 return reject(error.message);
             });

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -224,8 +224,7 @@ describe('Extension Test Suite', async () => {
 				assert.fail("Failure executing redeployOperator command");
 			}
 		});
-		// TODO - re-enable when fix is found for ECONNREFUSED error when running in Github runner
-		xit('Should download the container logs', async () => {
+		it('Should download the container logs', async () => {
 			const operatorContainerItems = await getOperatorContainerItems(imsOperatorItem);
 			assert.equal(operatorContainerItems.length, 2);
 

--- a/src/treeViews/providers/containerLogProvider.ts
+++ b/src/treeViews/providers/containerLogProvider.ts
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2023 IBM Inc. All rights reserved
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as vscode from 'vscode';
+import * as util from "../../utilities/util";
+import {Session} from "../../utilities/session";
+import {KubernetesObj} from "../../kubernetes/kubernetes";
+
+export class ContainerLogProvider implements vscode.TextDocumentContentProvider {
+    
+    constructor(private readonly session: Session){}
+
+    async provideTextDocumentContent(uri: vscode.Uri): Promise<string> {
+      if (this.session.loggedIntoOpenShift) {
+        const k8s = new KubernetesObj();
+        const {podName, containerName, follow} = util.parseContainerLogUri(uri);
+        const logData = await k8s.downloadContainerLogs(podName, containerName, follow);
+        if (logData) {
+          return logData;
+        }
+        return "";
+      }
+      return "";
+    }
+}

--- a/src/treeViews/providers/containerLogProvider.ts
+++ b/src/treeViews/providers/containerLogProvider.ts
@@ -15,8 +15,8 @@ export class ContainerLogProvider implements vscode.TextDocumentContentProvider 
     async provideTextDocumentContent(uri: vscode.Uri): Promise<string> {
       if (this.session.loggedIntoOpenShift) {
         const k8s = new KubernetesObj();
-        const {podName, containerName, follow} = util.parseContainerLogUri(uri);
-        const logData = await k8s.downloadContainerLogs(podName, containerName, follow);
+        const {podName, containerName} = util.parseContainerLogUri(uri);
+        const logData = await k8s.downloadContainerLogs(podName, containerName);
         if (logData) {
           return logData;
         }

--- a/src/treeViews/providers/verboseContainerLogProvider.ts
+++ b/src/treeViews/providers/verboseContainerLogProvider.ts
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2023 IBM Inc. All rights reserved
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as vscode from 'vscode';
+import * as util from "../../utilities/util";
+import {Session} from "../../utilities/session";
+import {KubernetesObj} from "../../kubernetes/kubernetes";
+
+export class VerboseContainerLogProvider implements vscode.TextDocumentContentProvider {
+    
+    constructor(private readonly session: Session){}
+
+    async provideTextDocumentContent(uri: vscode.Uri): Promise<string> {
+        if (this.session.loggedIntoOpenShift) {
+            const k8s = new KubernetesObj();
+            const uriObj = util.parseVerboseContainerLogUri(uri);
+            const logData = await k8s.downloadVerboseContainerLogs(uriObj.podName, uriObj.containerName, uriObj.apiVersion, uriObj.kind, uriObj.instanceName);
+            if (logData) {
+                return logData;
+            }
+            return "";
+        }
+        return "";
+    }
+}

--- a/src/utilities/commandConstants.ts
+++ b/src/utilities/commandConstants.ts
@@ -15,7 +15,6 @@ export enum VSCodeCommands {
 	redeployOperator = "operator-collection-sdk.redeployOperator",
 	deleteCustomResource = "operator-collection-sdk.deleteCustomResource",
 	downloadLogs = "operator-collection-sdk.downloadLogs",
-	followLogs = "operator-collection-sdk.followLogs",
 	downloadVerboseLogs = "operator-collection-sdk.downloadVerboseLogs",
 	openEditLink = "operator-collection-sdk.openEditLink",
 	openAddLink = "operator-collection-sdk.openAddLink",

--- a/src/utilities/commandConstants.ts
+++ b/src/utilities/commandConstants.ts
@@ -15,6 +15,7 @@ export enum VSCodeCommands {
 	redeployOperator = "operator-collection-sdk.redeployOperator",
 	deleteCustomResource = "operator-collection-sdk.deleteCustomResource",
 	downloadLogs = "operator-collection-sdk.downloadLogs",
+	followLogs = "operator-collection-sdk.followLogs",
 	downloadVerboseLogs = "operator-collection-sdk.downloadVerboseLogs",
 	openEditLink = "operator-collection-sdk.openEditLink",
 	openAddLink = "operator-collection-sdk.openAddLink",

--- a/src/utilities/util.ts
+++ b/src/utilities/util.ts
@@ -535,10 +535,7 @@ export async function pollRun(attempts: number): Promise<void> {
 	}, 5000);
 }
 
-export function buildContainerLogUri(podName: string, containerName: string, follow?: boolean): vscode.Uri {
-	if (follow) {
-		return vscode.Uri.parse(`${logScheme}://${podName}/${containerName}/follow`);
-	} 
+export function buildContainerLogUri(podName: string, containerName: string): vscode.Uri {
 	return vscode.Uri.parse(`${logScheme}://${podName}/${containerName}`);
 }
 
@@ -549,22 +546,16 @@ export function buildVerboseContainerLogUri(podName: string, containerName: stri
 export function parseContainerLogUri(uri: vscode.Uri): {
 	podName: string;
 	containerName: string;
-	follow: boolean;
 } {
 	if (uri.scheme !== logScheme) {
 		throw new Error("Uri is not of the containerLog scheme");
 	}
 
 	const uriSplitArray = uri.path.split("/");
-	const uriObj = {
+	return {
 		podName: uri.authority,
 		containerName: uriSplitArray[1],
-		follow: false
 	};
-	if (uriSplitArray.length === 3 && uriSplitArray[2] === "follow") {
-		uriObj.follow = true; 
-	}
-	return uriObj;
 }
 
 export function parseVerboseContainerLogUri(uri: vscode.Uri): {

--- a/src/utilities/util.ts
+++ b/src/utilities/util.ts
@@ -543,7 +543,7 @@ export function buildContainerLogUri(podName: string, containerName: string, fol
 }
 
 export function buildVerboseContainerLogUri(podName: string, containerName: string, apiVersion: string, kind: string, instanceName: string): vscode.Uri {
-	return vscode.Uri.parse(`${logScheme}://${podName}/${containerName}/${apiVersion}/${kind}/${instanceName}`);
+	return vscode.Uri.parse(`${verboseLogScheme}://${podName}/${containerName}/${apiVersion}/${kind}/${instanceName}`);
 }
 
 export function parseContainerLogUri(uri: vscode.Uri): {
@@ -557,11 +557,11 @@ export function parseContainerLogUri(uri: vscode.Uri): {
 
 	const uriSplitArray = uri.path.split("/");
 	const uriObj = {
-		podName: uriSplitArray[2],
-		containerName: uriSplitArray[3],
+		podName: uri.authority,
+		containerName: uriSplitArray[1],
 		follow: false
 	};
-	if (uriSplitArray.length === 5 && uriSplitArray[4] === "follow") {
+	if (uriSplitArray.length === 3 && uriSplitArray[2] === "follow") {
 		uriObj.follow = true; 
 	}
 	return uriObj;
@@ -580,10 +580,10 @@ export function parseVerboseContainerLogUri(uri: vscode.Uri): {
 
 	const uriSplitArray = uri.path.split("/");
 	return {
-		podName: uriSplitArray[2],
-		containerName: uriSplitArray[3],
-		apiVersion: uriSplitArray[4],
-		kind: uriSplitArray[5],
-		instanceName: uriSplitArray[6],
+		podName: uri.authority,
+		containerName: uriSplitArray[1],
+		apiVersion: uriSplitArray[2],
+		kind: uriSplitArray[3],
+		instanceName: uriSplitArray[4],
 	};
 }

--- a/src/utilities/util.ts
+++ b/src/utilities/util.ts
@@ -34,6 +34,9 @@ export const zosEndpointApiVersion: string =  "v2beta2";
 export const subOperatorConfigApiVersion: string =  "v2beta2";
 export const operatorCollectionApiVersion: string =  "v2beta2";
 
+export const logScheme: string = "containerLogs";
+export const verboseLogScheme: string = "verboseContainerLogs";
+
 
 /**
  * Retrieve the current workspace root directory if it exists
@@ -530,4 +533,57 @@ export async function pollRun(attempts: number): Promise<void> {
 			clearInterval(interval);
 		}
 	}, 5000);
+}
+
+export function buildContainerLogUri(podName: string, containerName: string, follow?: boolean): vscode.Uri {
+	if (follow) {
+		return vscode.Uri.parse(`${logScheme}://${podName}/${containerName}/follow`);
+	} 
+	return vscode.Uri.parse(`${logScheme}://${podName}/${containerName}`);
+}
+
+export function buildVerboseContainerLogUri(podName: string, containerName: string, apiVersion: string, kind: string, instanceName: string): vscode.Uri {
+	return vscode.Uri.parse(`${logScheme}://${podName}/${containerName}/${apiVersion}/${kind}/${instanceName}`);
+}
+
+export function parseContainerLogUri(uri: vscode.Uri): {
+	podName: string;
+	containerName: string;
+	follow: boolean;
+} {
+	if (uri.scheme !== logScheme) {
+		throw new Error("Uri is not of the containerLog scheme");
+	}
+
+	const uriSplitArray = uri.path.split("/");
+	const uriObj = {
+		podName: uriSplitArray[2],
+		containerName: uriSplitArray[3],
+		follow: false
+	};
+	if (uriSplitArray.length === 5 && uriSplitArray[4] === "follow") {
+		uriObj.follow = true; 
+	}
+	return uriObj;
+}
+
+export function parseVerboseContainerLogUri(uri: vscode.Uri): {
+	podName: string;
+	containerName: string;
+	apiVersion: string;
+	kind: string;
+	instanceName: string;
+} {
+	if (uri.scheme !== verboseLogScheme) {
+		throw new Error("Uri is not of the verboseContainerLog scheme");
+	}
+
+	const uriSplitArray = uri.path.split("/");
+	return {
+		podName: uriSplitArray[2],
+		containerName: uriSplitArray[3],
+		apiVersion: uriSplitArray[4],
+		kind: uriSplitArray[5],
+		instanceName: uriSplitArray[6],
+	};
 }


### PR DESCRIPTION
fixes #2 
Converted log downloads to virtual documents, to remove the unnecessary log files being downloaded to the workspace