### PR TITLE
Refresh OpenShift Cluster Info when updated outside of editor

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,7 +104,13 @@
       },
       {
         "command": "operator-collection-sdk.resourceRefresh",
-        "title": "OpenShift Resource Refresh",
+        "title": "Refresh",
+        "category": "OC-SDK",
+        "icon": "$(extensions-refresh)"
+      },
+      {
+        "command": "operator-collection-sdk.refreshAll",
+        "title": "Refresh",
         "category": "OC-SDK",
         "icon": "$(extensions-refresh)"
       },
@@ -188,6 +194,11 @@
         {
           "command": "operator-collection-sdk.resourceRefresh",
           "when": "view == operator-collection-sdk.resources",
+          "group": "navigation"
+        },
+        {
+          "command": "operator-collection-sdk.refreshAll",
+          "when": "view == operator-collection-sdk.openshiftClusterInfo",
           "group": "navigation"
         }
       ],

--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
         "icon": "$(extensions-refresh)"
       },
       {
-        "command": "operator-collection-sdk.refreshAll",
+        "command": "operator-collection-sdk.refreshOpenShiftInfo",
         "title": "Refresh",
         "category": "OC-SDK",
         "icon": "$(extensions-refresh)"
@@ -197,7 +197,7 @@
           "group": "navigation"
         },
         {
-          "command": "operator-collection-sdk.refreshAll",
+          "command": "operator-collection-sdk.refreshOpenShiftInfo",
           "when": "view == operator-collection-sdk.openshiftClusterInfo",
           "group": "navigation"
         }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -9,6 +9,7 @@ import * as path from 'path';
 import {VSCodeCommands, VSCodeViewIds} from './utilities/commandConstants';
 import {OperatorsTreeProvider} from './treeViews/providers/operatorProvider';
 import {OperatorItem} from './treeViews/operatorItems/operatorItem';
+import {OpenShiftItem} from './treeViews/openshiftItems/openshiftItem';
 import {ResourcesTreeProvider} from './treeViews/providers/resourceProvider';
 import {OpenShiftTreeProvider} from './treeViews/providers/openshiftProvider';
 import {LinksTreeProvider} from './treeViews/providers/linkProvider';
@@ -120,13 +121,15 @@ function installOcSdk(command: string, ocSdkCmd: OcSdkCommand, session: Session,
 }
 
 function updateProject(command: string, ocCmd: OcCommand, outputChannel?: vscode.OutputChannel): vscode.Disposable {
-	return vscode.commands.registerCommand(command, async (namespaceArg?: string, logPath?: string) => {
+	return vscode.commands.registerCommand(command, async (arg: OpenShiftItem, logPath?: string) => {
+		const k8s = new KubernetesObj();
 		let namespace: string | undefined;
-		if (namespaceArg) {
-			namespace = namespaceArg;
-		} else {
+		if (arg.description === k8s.namespace) { // implies that the edit button was selected in the editor
 			namespace = await util.generateProjectDropDown();
+		} else { // allows for tests to pass in new namespace directly
+			namespace = arg.description;
 		}
+
 		if (namespace) {
 			ocCmd.runOcProjectCommand(namespace, outputChannel, logPath).then(() => {
 				vscode.window.showInformationMessage("Successfully updating Project on OpenShift cluster");

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -34,13 +34,12 @@ export async function activate(context: vscode.ExtensionContext) {
 	(global as any).testExtensionContext = context;
 	initResources(context);
 
-	const k8s = new KubernetesObj();
 	const ocSdkCmd = new OcSdkCommand();
 	const ocCmd = new OcCommand();
-	const session = new Session(ocSdkCmd, k8s);
+	const session = new Session(ocSdkCmd);
 
-	const isOcSDKinstalled = await session.validateOcSDKInstallation();
-	const userLoggedIntoOCP = await session.validateOpenShiftAccess();
+	await session.validateOcSDKInstallation();
+	await session.validateOpenShiftAccess();
 	const outputChannel = vscode.window.createOutputChannel('IBM Operator Collection SDK');
 
 
@@ -63,9 +62,9 @@ export async function activate(context: vscode.ExtensionContext) {
 	vscode.workspace.registerTextDocumentContentProvider(util.customResourceScheme, customResourceDisplayProvider);
 
 	
-	// Register Comands
-	vscode.commands.executeCommand("setContext", VSCodeCommands.sdkInstalled, isOcSDKinstalled);
-	vscode.commands.executeCommand("setContext", VSCodeCommands.loggedIn, userLoggedIntoOCP);
+	// Register Commands
+	vscode.commands.executeCommand("setContext", VSCodeCommands.sdkInstalled, await session.validateOcSDKInstallation());
+	vscode.commands.executeCommand("setContext", VSCodeCommands.loggedIn, await session.validateOpenShiftAccess());
 	context.subscriptions.push(logIn(VSCodeCommands.login, ocCmd, session));
 	context.subscriptions.push(installOcSdk(VSCodeCommands.install, ocSdkCmd, session, outputChannel));
 	context.subscriptions.push(updateProject(VSCodeCommands.updateProject, ocCmd));
@@ -73,9 +72,9 @@ export async function activate(context: vscode.ExtensionContext) {
 	context.subscriptions.push(executeSimpleSdkCommand(VSCodeCommands.deleteOperator, outputChannel));
 	context.subscriptions.push(executeSimpleSdkCommand(VSCodeCommands.redeployCollection, outputChannel));
 	context.subscriptions.push(executeSimpleSdkCommand(VSCodeCommands.redeployOperator, outputChannel));
-	context.subscriptions.push(deleteCustomResource(VSCodeCommands.deleteCustomResource, k8s));
-	context.subscriptions.push(executeContainerViewLogCommand(VSCodeCommands.viewLogs, k8s));
-	context.subscriptions.push(executeContainerViewLogCommand(VSCodeCommands.viewVerboseLogs, k8s));
+	context.subscriptions.push(deleteCustomResource(VSCodeCommands.deleteCustomResource));
+	context.subscriptions.push(executeContainerViewLogCommand(VSCodeCommands.viewLogs));
+	context.subscriptions.push(executeContainerViewLogCommand(VSCodeCommands.viewVerboseLogs));
 	context.subscriptions.push(executeOpenLinkCommand(VSCodeCommands.openEditLink));
 	context.subscriptions.push(executeOpenLinkCommand(VSCodeCommands.openAddLink));
 	context.subscriptions.push(executeOpenLinkCommand(VSCodeCommands.openLink));
@@ -91,6 +90,9 @@ export async function activate(context: vscode.ExtensionContext) {
 		openshiftTreeProvider.refresh();
 		operatorTreeProvider.refresh();
 		resourceTreeProvider.refresh();
+	}));
+	context.subscriptions.push(vscode.commands.registerCommand(VSCodeCommands.refreshOpenShiftInfo, () => {
+		openshiftTreeProvider.refresh();
 	}));
 }
 
@@ -209,8 +211,9 @@ function viewResourceCommand(command: string): vscode.Disposable {
 	});
 }
 
-function executeContainerViewLogCommand(command: string, k8s: KubernetesObj): vscode.Disposable {
+function executeContainerViewLogCommand(command: string): vscode.Disposable {
 	return vscode.commands.registerCommand(command, async (containerItemArgs: OperatorContainerItem, logPath?: string) => {
+		const k8s = new KubernetesObj();
 		const pwd = util.getCurrentWorkspaceRootFolder();
 		if (!pwd) {
 			vscode.window.showErrorMessage("Unable to execute command when workspace is empty");
@@ -352,8 +355,9 @@ function executeSdkCommandWithUserInput(command: string, outputChannel?: vscode.
 	});
 }
 
-function deleteCustomResource(command: string, k8s: KubernetesObj) {
+function deleteCustomResource(command: string) {
 	return vscode.commands.registerCommand(command, async (customResourcArg: CustomResourcesItem) => {
+		const k8s = new KubernetesObj();
 		const name = customResourcArg.customResourceObj.metadata.name;
 		const apiVersion = customResourcArg.customResourceObj.apiVersion.split("/")[1];
 		const kind = customResourcArg.customResourceObj.kind;

--- a/src/kubernetes/kubernetes.ts
+++ b/src/kubernetes/kubernetes.ts
@@ -5,8 +5,6 @@
 
 import * as vscode from 'vscode';
 import * as k8s from '@kubernetes/client-node';
-import * as fs from "fs";
-import * as path from 'path';
 import * as util from '../utilities/util';
 import {OcCommand} from "../shellCommands/ocCommand";
 import {KubernetesContext} from "./kubernetesContext";

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -6,11 +6,11 @@ import * as child_process from 'child_process';
 import {VSCodeCommands} from '../../utilities/commandConstants';
 import * as helper from '../helper';
 import {OperatorItem} from "../../treeViews/operatorItems/operatorItem";
+import {OpenShiftItem} from '../../treeViews/openshiftItems/openshiftItem';
 import {OperatorContainerItem} from "../../treeViews/operatorItems/operatorContainerItem";
 import {OperatorPodItem} from "../../treeViews/operatorItems/operatorPodItem";
 import {OperatorsTreeProvider} from '../../treeViews/providers/operatorProvider';
 import {ResourcesTreeProvider} from '../../treeViews/providers/resourceProvider';
-import {OpenShiftTreeProvider} from '../../treeViews/providers/openshiftProvider';
 import {ZosEndpointItem} from '../../treeViews/resourceItems/zosendpointItem';
 import {ZosEndpointsItem} from '../../treeViews/resourceItems/zosendpointsItem';
 import {OperatorCollectionItem} from '../../treeViews/resourceItems/operatorCollectionItem';
@@ -46,9 +46,6 @@ describe('Extension Test Suite', async () => {
 	}
 	
 	const zosCloudBrokerGroup: string =  "zoscb.ibm.com";
-	const clusterServiceVersionGroup: string =  "operators.coreos.com";
-	const customResourceGroup: string =  "suboperator.zoscb.ibm.com";
-	const clusterServiceVersionApiVersion: string = "v1alpha1";
 	const zosEndpointApiVersion: string =  "v2beta2";
 	const subOperatorConfigApiVersion: string =  "v2beta2";
 	const operatorCollectionApiVersion: string =  "v2beta2";
@@ -107,7 +104,8 @@ describe('Extension Test Suite', async () => {
 		}
 
 		try {
-			vscode.commands.executeCommand(VSCodeCommands.updateProject, namespace, updateProjectLogPath);
+			const namespaceObj = new OpenShiftItem("OpenShift Namespace", namespace, new vscode.ThemeIcon("account"), "openshift-namespace");
+			vscode.commands.executeCommand(VSCodeCommands.updateProject, namespaceObj, updateProjectLogPath);
 			await helper.sleep(5000);
 		} catch (e) {
 			console.log("Printing Update Project command logs");

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -123,7 +123,7 @@ describe('Extension Test Suite', async () => {
 
 		await installOperatorCollectionSDK(installSdkLogPath);
 
-		session = new Session(ocSdkCmd, k8s);
+		session = new Session(ocSdkCmd);
 		await session.validateOcSDKInstallation();
 		await session.validateOpenShiftAccess();
 
@@ -609,7 +609,7 @@ describe('Extension Test Suite', async () => {
 			const doc = await vscode.workspace.openTextDocument(`${helper.cicsOperatorCollectionPath}/operator-config.yml`);
 			const editor = await vscode.window.showTextDocument(doc, vscode.ViewColumn.Beside, false);
 			const text = doc.getText();
-			const match = text.match('displayName')
+			const match = text.match('displayName');
 			if(match && match.index){
 				const matchRange = doc.getWordRangeAtPosition(doc.positionAt(match.index));
 				if(matchRange){
@@ -625,7 +625,7 @@ describe('Extension Test Suite', async () => {
 			await helper.sleep(2000); // Wait for linter
 			let diagnostics = vscode.languages.getDiagnostics(doc.uri);
 			assert.equal(diagnostics[0].message, "Property linterShouldFlagThis is not allowed.");
-		})
+		});
 	});
 
 });

--- a/src/treeViews/providers/containerLogProvider.ts
+++ b/src/treeViews/providers/containerLogProvider.ts
@@ -9,8 +9,20 @@ import {Session} from "../../utilities/session";
 import {KubernetesObj} from "../../kubernetes/kubernetes";
 
 export class ContainerLogProvider implements vscode.TextDocumentContentProvider {
-    
-    constructor(private readonly session: Session){}
+    // Static property to store the instances
+    private static containerLogProviders: ContainerLogProvider[] = [];
+
+    constructor(private readonly session: Session){
+      // Store the instances on the static property
+      ContainerLogProvider.containerLogProviders.push(this);
+    }
+
+    static async updateSession(): Promise<void> {
+      for (const provider of ContainerLogProvider.containerLogProviders) {
+        await provider.session.validateOcSDKInstallation();
+        await provider.session.validateOpenShiftAccess();
+      }
+    }
 
     async provideTextDocumentContent(uri: vscode.Uri): Promise<string> {
       if (this.session.loggedIntoOpenShift) {

--- a/src/treeViews/providers/customResourceDisplayProviders.ts
+++ b/src/treeViews/providers/customResourceDisplayProviders.ts
@@ -10,8 +10,20 @@ import {Session} from "../../utilities/session";
 import {KubernetesObj} from "../../kubernetes/kubernetes";
 
 export class CustomResourceDisplayProvider implements vscode.TextDocumentContentProvider {
-    
-  constructor(private readonly session: Session){}
+  // Static property to store the instances
+  private static customResourceDisplayProviders: CustomResourceDisplayProvider[] = [];
+
+  constructor(private readonly session: Session){
+    // Store the instances on the static property
+    CustomResourceDisplayProvider.customResourceDisplayProviders.push(this);
+  }
+
+  static async updateSession(): Promise<void> {
+    for (const provider of CustomResourceDisplayProvider.customResourceDisplayProviders) {
+      await provider.session.validateOcSDKInstallation();
+      await provider.session.validateOpenShiftAccess();
+    }
+  }
 
   async provideTextDocumentContent(uri: vscode.Uri): Promise<string> {
     if (this.session.loggedIntoOpenShift) {

--- a/src/treeViews/providers/openshiftProvider.ts
+++ b/src/treeViews/providers/openshiftProvider.ts
@@ -7,14 +7,31 @@ import * as vscode from 'vscode';
 import {OpenShiftItem} from "../openshiftItems/openshiftItem";
 import {KubernetesObj} from "../../kubernetes/kubernetes";
 import {Session} from "../../utilities/session";
+import {ResourcesTreeProvider} from '../../treeViews/providers/resourceProvider';
+import {OperatorsTreeProvider} from '../../treeViews/providers/operatorProvider';
+import {ContainerLogProvider} from '../../treeViews/providers/containerLogProvider';
+import {CustomResourceDisplayProvider} from '../../treeViews/providers/customResourceDisplayProviders';
+import {VerboseContainerLogProvider} from '../../treeViews/providers/verboseContainerLogProvider';
 
 type TreeItem = OpenShiftItem | undefined | void;
 
 export class OpenShiftTreeProvider implements vscode.TreeDataProvider<vscode.TreeItem> {
+    // Static property to store the instances
+    private static openshiftTreeProviders: OpenShiftTreeProvider[] = [];
     private _onDidChangeTreeData: vscode.EventEmitter<TreeItem> = new vscode.EventEmitter<TreeItem>();
 	readonly onDidChangeTreeData: vscode.Event<TreeItem> = this._onDidChangeTreeData.event;
 
-    constructor(private readonly session: Session){}
+    constructor(private readonly session: Session){
+        // Store the instances on the static property
+        OpenShiftTreeProvider.openshiftTreeProviders.push(this);
+    }
+
+    static async updateSession(): Promise<void> {
+        for (const provider of OpenShiftTreeProvider.openshiftTreeProviders) {
+            await provider.session.validateOcSDKInstallation();
+            await provider.session.validateOpenShiftAccess();
+        }
+    }
 
     refresh(): void {
         this._onDidChangeTreeData.fire();
@@ -27,11 +44,19 @@ export class OpenShiftTreeProvider implements vscode.TreeDataProvider<vscode.Tre
     async getChildren(element?: OpenShiftItem): Promise<OpenShiftItem[]> {
         const links: Array<OpenShiftItem> = [];
         const k8s = new KubernetesObj();
-        if (!element && this.session.loggedIntoOpenShift) {
-            links.push(new OpenShiftItem("OpenShift Cluster", k8s.openshiftServerURL, new vscode.ThemeIcon("cloud"), "openshift-cluster"));
-            links.push(new OpenShiftItem("OpenShift Namespace", k8s.namespace, new vscode.ThemeIcon("account"), "openshift-namespace"));
-        }
-
-        return links;
+        const updateOpenshiftTree = OpenShiftTreeProvider.updateSession();
+        const updateOperatorsTree = OperatorsTreeProvider.updateSession();
+        const updateResourcesTree =  ResourcesTreeProvider.updateSession();
+        const updateContainerLogsProvider = ContainerLogProvider.updateSession();
+        const updateCustomResourceDeployProvider = CustomResourceDisplayProvider.updateSession();
+        const updateVerboseContainerLogProvider = VerboseContainerLogProvider.updateSession();
+        return Promise.all([updateOpenshiftTree, updateOperatorsTree, updateResourcesTree, updateContainerLogsProvider, updateCustomResourceDeployProvider, updateVerboseContainerLogProvider]).then(() => {
+            if (this.session.loggedIntoOpenShift) {
+                links.push(new OpenShiftItem("OpenShift Cluster", k8s.openshiftServerURL, new vscode.ThemeIcon("cloud"), "openshift-cluster"));
+                links.push(new OpenShiftItem("OpenShift Namespace", k8s.namespace, new vscode.ThemeIcon("account"), "openshift-namespace"));
+            }
+            
+            return links;
+        });
     } 
 }

--- a/src/treeViews/providers/verboseContainerLogProvider.ts
+++ b/src/treeViews/providers/verboseContainerLogProvider.ts
@@ -9,8 +9,20 @@ import {Session} from "../../utilities/session";
 import {KubernetesObj} from "../../kubernetes/kubernetes";
 
 export class VerboseContainerLogProvider implements vscode.TextDocumentContentProvider {
-    
-    constructor(private readonly session: Session){}
+    // Static property to store the instances
+    private static verboseContainerLogProviders: VerboseContainerLogProvider[] = [];
+
+    constructor(private readonly session: Session){
+        // Store the instances on the static property
+        VerboseContainerLogProvider.verboseContainerLogProviders.push(this);
+    }
+
+    static async updateSession(): Promise<void> {
+        for (const provider of VerboseContainerLogProvider.verboseContainerLogProviders) {
+            await provider.session.validateOcSDKInstallation();
+            await provider.session.validateOpenShiftAccess();
+        }
+    }
 
     async provideTextDocumentContent(uri: vscode.Uri): Promise<string> {
         if (this.session.loggedIntoOpenShift) {

--- a/src/utilities/commandConstants.ts
+++ b/src/utilities/commandConstants.ts
@@ -22,7 +22,8 @@ export enum VSCodeCommands {
 	openLink = "operator-collection-sdk.openLink",
 	refresh = "operator-collection-sdk.refresh",
 	resourceRefresh = "operator-collection-sdk.resourceRefresh",
-	refreshAll = "operator-collection-sdk.refreshAll"
+	refreshAll = "operator-collection-sdk.refreshAll",
+	refreshOpenShiftInfo = "operator-collection-sdk.refreshOpenShiftInfo"
 }
 
 export enum VSCodeViewIds {

--- a/src/utilities/session.ts
+++ b/src/utilities/session.ts
@@ -11,7 +11,7 @@ export class Session {
     public ocSdkInstalled: boolean = false;
     public loggedIntoOpenShift: boolean = false;
     
-    constructor(public readonly ocSdkCmd: OcSdkCommand, public readonly k8s: KubernetesContext){};
+    constructor(public readonly ocSdkCmd: OcSdkCommand){};
 
     /**
      * Validates that the IBM Operator Collection SDK is installed
@@ -35,7 +35,8 @@ export class Session {
      * @returns - A promise containing a boolean, returning true if the user has access
      */
     async validateOpenShiftAccess(): Promise<boolean> {
-        return this.k8s.coreV1Api.listNamespacedPod(this.k8s.namespace).then(() => {
+        const k8s = new KubernetesContext();
+        return k8s.coreV1Api.listNamespacedPod(k8s.namespace).then(() => {
             this.loggedIntoOpenShift = true;
             return true;
         }).catch((e) => {


### PR DESCRIPTION
fixes #3 
- Added refresh button to OpenShift Cluster Info panel to update project when updated outside of editor
- Moved k8s class initialization so that the namespace is refreshed when project is updated
- Remove all Operator and Resource Items when logged out of cluster, and precent OpenShift Log In button

fixes #26 
- Accept OpenShfitItem as argument to `updateProject()`