### PR TITLE
added validation check to cluster commands in bug fix #39

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ node_modules
 *.vsix
 .DS_Store
 builds/
+.idea/**

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -269,44 +269,48 @@ function executeSimpleSdkCommand(command: string, outputChannel?: vscode.OutputC
 			}
 		}
 		if (workspacePath) {
-			let ocSdkCommand = new OcSdkCommand(workspacePath);
-			outputChannel?.show();
-			switch(command) {
-				case VSCodeCommands.deleteOperator: {
-					vscode.window.showInformationMessage("Delete Operator request in progress");
-					const poll = util.pollRun(10);
-					const runDeleteOperatorCommand = ocSdkCommand.runDeleteOperatorCommand(outputChannel, logPath);
-					Promise.all([poll, runDeleteOperatorCommand]).then(() => {
-						vscode.window.showInformationMessage("Delete Operator command executed successfully");
-						vscode.commands.executeCommand(VSCodeCommands.refresh);
-					}).catch((e) => {
-						vscode.window.showInformationMessage(`Failure executing Delete Operator command: RC ${e}`);
-					});
-					break;
-				}
-				case VSCodeCommands.redeployCollection: {
-					vscode.window.showInformationMessage("Redeploy Collection request in progress");
-					const poll = util.pollRun(30);
-					const runRedeployCollectionCommand = ocSdkCommand.runRedeployCollectionCommand(outputChannel, logPath);
-					Promise.all([poll, runRedeployCollectionCommand]).then(() => {
-						vscode.window.showInformationMessage("Redeploy Collection command executed successfully");
-						vscode.commands.executeCommand(VSCodeCommands.refresh);
-					}).catch((e) => {
-						vscode.window.showInformationMessage(`Failure executing Redeploy Collection command: RC ${e}`);
-					});
-					break;
-				}
-				case VSCodeCommands.redeployOperator: {
-					vscode.window.showInformationMessage("Redeploy Operator request in progress");
-					const poll = util.pollRun(40);
-					const runRedeployOperatorCommand = ocSdkCommand.runRedeployOperatorCommand(outputChannel, logPath);
-					Promise.all([poll, runRedeployOperatorCommand]).then(() => {
-						vscode.window.showInformationMessage("Redeploy Operator command executed successfully");
-						vscode.commands.executeCommand(VSCodeCommands.refresh);
-					}).catch((e) => {
-						vscode.window.showInformationMessage(`Failure executing Redeploy Operator command: RC ${e}`);
-					});
-					break;
+			const k8s = new KubernetesObj();
+			const validNamespace = await k8s.validateNamespaceExists();
+			if (validNamespace) {
+				let ocSdkCommand = new OcSdkCommand(workspacePath);
+				outputChannel?.show();
+				switch(command) {
+					case VSCodeCommands.deleteOperator: {
+						vscode.window.showInformationMessage("Delete Operator request in progress");
+						const poll = util.pollRun(10);
+						const runDeleteOperatorCommand = ocSdkCommand.runDeleteOperatorCommand(outputChannel, logPath);
+						Promise.all([poll, runDeleteOperatorCommand]).then(() => {
+							vscode.window.showInformationMessage("Delete Operator command executed successfully");
+							vscode.commands.executeCommand(VSCodeCommands.refresh);
+						}).catch((e) => {
+							vscode.window.showInformationMessage(`Failure executing Delete Operator command: RC ${e}`);
+						});
+						break;
+					}
+					case VSCodeCommands.redeployCollection: {
+						vscode.window.showInformationMessage("Redeploy Collection request in progress");
+						const poll = util.pollRun(30);
+						const runRedeployCollectionCommand = ocSdkCommand.runRedeployCollectionCommand(outputChannel, logPath);
+						Promise.all([poll, runRedeployCollectionCommand]).then(() => {
+							vscode.window.showInformationMessage("Redeploy Collection command executed successfully");
+							vscode.commands.executeCommand(VSCodeCommands.refresh);
+						}).catch((e) => {
+							vscode.window.showInformationMessage(`Failure executing Redeploy Collection command: RC ${e}`);
+						});
+						break;
+					}
+					case VSCodeCommands.redeployOperator: {
+						vscode.window.showInformationMessage("Redeploy Operator request in progress");
+						const poll = util.pollRun(40);
+						const runRedeployOperatorCommand = ocSdkCommand.runRedeployOperatorCommand(outputChannel, logPath);
+						Promise.all([poll, runRedeployOperatorCommand]).then(() => {
+							vscode.window.showInformationMessage("Redeploy Operator command executed successfully");
+							vscode.commands.executeCommand(VSCodeCommands.refresh);
+						}).catch((e) => {
+							vscode.window.showInformationMessage(`Failure executing Redeploy Operator command: RC ${e}`);
+						});
+						break;
+					}
 				}
 			}
 		}
@@ -331,24 +335,28 @@ function executeSdkCommandWithUserInput(command: string, outputChannel?: vscode.
 			}
 		}
 		if (workspacePath) {
-			outputChannel?.show();
-			if (command === VSCodeCommands.createOperator) {
-				let playbookArgs = await util.requestOperatorInfo(workspacePath);
-				if (playbookArgs) {
-					let ocSdkCommand = new OcSdkCommand(workspacePath);
-					if (playbookArgs.length === 1 && playbookArgs[0].includes("ocsdk-extra-vars")) {
-						vscode.window.showInformationMessage("Create Operator request in progress using local variables file");
-					} else {
-						vscode.window.showInformationMessage("Create Operator request in progress");
+			const k8s = new KubernetesObj();
+			const validNamespace = await k8s.validateNamespaceExists();
+			if (validNamespace) {
+				outputChannel?.show();
+				if (command === VSCodeCommands.createOperator) {
+					let playbookArgs = await util.requestOperatorInfo(workspacePath);
+					if (playbookArgs) {
+						let ocSdkCommand = new OcSdkCommand(workspacePath);
+						if (playbookArgs.length === 1 && playbookArgs[0].includes("ocsdk-extra-vars")) {
+							vscode.window.showInformationMessage("Create Operator request in progress using local variables file");
+						} else {
+							vscode.window.showInformationMessage("Create Operator request in progress");
+						}
+						const poll = util.pollRun(40);
+						const runCreateOperatorCommand = ocSdkCommand.runCreateOperatorCommand(playbookArgs, outputChannel, logPath);
+						Promise.all([poll, runCreateOperatorCommand]).then(() => {
+							vscode.window.showInformationMessage("Create Operator command executed successfully");
+							vscode.commands.executeCommand(VSCodeCommands.refresh);
+						}).catch((e) => {
+							vscode.window.showInformationMessage(`Failure executing Create Operator command: RC ${e}`);
+						});
 					}
-					const poll = util.pollRun(40);
-					const runCreateOperatorCommand = ocSdkCommand.runCreateOperatorCommand(playbookArgs, outputChannel, logPath);
-					Promise.all([poll, runCreateOperatorCommand]).then(() => {
-						vscode.window.showInformationMessage("Create Operator command executed successfully");
-						vscode.commands.executeCommand(VSCodeCommands.refresh);
-					}).catch((e) => {
-						vscode.window.showInformationMessage(`Failure executing Create Operator command: RC ${e}`);
-					});
 				}
 			}
 		};
@@ -358,21 +366,26 @@ function executeSdkCommandWithUserInput(command: string, outputChannel?: vscode.
 function deleteCustomResource(command: string) {
 	return vscode.commands.registerCommand(command, async (customResourcArg: CustomResourcesItem) => {
 		const k8s = new KubernetesObj();
-		const name = customResourcArg.customResourceObj.metadata.name;
-		const apiVersion = customResourcArg.customResourceObj.apiVersion.split("/")[1];
-		const kind = customResourcArg.customResourceObj.kind;
-		const poll = util.pollRun(15);
-		const deleteCustomResourceCmd = k8s.deleteCustomResource(name, apiVersion, kind);
-		Promise.all([poll, deleteCustomResourceCmd]).then((values) => {
-			const deleteSuccessful = values[1];
-			if (deleteSuccessful) {
-				vscode.window.showInformationMessage(`Successfully deleted ${kind} resource`);
-				vscode.commands.executeCommand(VSCodeCommands.resourceRefresh);
-			} else {
-				vscode.window.showErrorMessage(`Failed to delete ${kind} resource`);
-			}
-		}).catch((e) => {
-			vscode.window.showErrorMessage(`Failed to delete ${kind} resource: ${e}`);
-		});
+		const validNamespace = await k8s.validateNamespaceExists();
+
+		// validation may not be necessary in this case
+		if (validNamespace) {
+			const name = customResourcArg.customResourceObj.metadata.name;
+			const apiVersion = customResourcArg.customResourceObj.apiVersion.split("/")[1];
+			const kind = customResourcArg.customResourceObj.kind;
+			const poll = util.pollRun(15);
+			const deleteCustomResourceCmd = k8s.deleteCustomResource(name, apiVersion, kind);
+			Promise.all([poll, deleteCustomResourceCmd]).then((values) => {
+				const deleteSuccessful = values[1];
+				if (deleteSuccessful) {
+					vscode.window.showInformationMessage(`Successfully deleted ${kind} resource`);
+					vscode.commands.executeCommand(VSCodeCommands.resourceRefresh);
+				} else {
+					vscode.window.showErrorMessage(`Failed to delete ${kind} resource`);
+				}
+			}).catch((e) => {
+				vscode.window.showErrorMessage(`Failed to delete ${kind} resource: ${e}`);
+			});
+		}
 	});
 }

--- a/src/kubernetes/kubernetes.ts
+++ b/src/kubernetes/kubernetes.ts
@@ -499,7 +499,7 @@ export class KubernetesObj extends KubernetesContext {
                     try {
                         const ocCmd = new OcCommand();
                         const _ = await ocCmd.runOcProjectCommand(projectSelection);
-                        vscode.window.showInformationMessage("Successfully updating Project on OpenShift cluster");
+                        vscode.window.showInformationMessage("Successfully updated Project on OpenShift cluster");
                         vscode.commands.executeCommand(VSCodeCommands.refreshAll);
                     } catch (error) {
                         vscode.window.showErrorMessage(`Failure updating Project on OpenShift cluster: ${error}`);

--- a/src/kubernetes/kubernetes.ts
+++ b/src/kubernetes/kubernetes.ts
@@ -8,6 +8,7 @@ import * as k8s from '@kubernetes/client-node';
 import * as util from '../utilities/util';
 import {OcCommand} from "../shellCommands/ocCommand";
 import {KubernetesContext} from "./kubernetesContext";
+import { VSCodeCommands } from '../utilities/commandConstants';
 
 export interface ObjectList {
     apiVersion: string;
@@ -479,5 +480,37 @@ export class KubernetesObj extends KubernetesContext {
             vscode.window.showErrorMessage(msg);
             return undefined;
         });
+    }
+
+    /**
+     * Validates if the namespace exists on the cluster
+     * @returns - A promise containing a boolean
+     */
+    public async validateNamespaceExists(): Promise<boolean | undefined> {
+        try {
+            const namespaceList = await this.getNamespaceList();
+            if (namespaceList?.includes(this.namespace)) {
+                return true;
+            } else {
+                vscode.window.showWarningMessage(`Project "${this.namespace}" does not exist on your current cluster. Please update your project`);
+
+                const projectSelection = await util.generateProjectDropDown(namespaceList);
+                if (projectSelection) {
+                    try {
+                        const ocCmd = new OcCommand();
+                        const _ = await ocCmd.runOcProjectCommand(projectSelection);
+                        vscode.window.showInformationMessage("Successfully updating Project on OpenShift cluster");
+                        vscode.commands.executeCommand(VSCodeCommands.refreshAll);
+                    } catch (error) {
+                        vscode.window.showErrorMessage(`Failure updating Project on OpenShift cluster: ${error}`);
+                    }
+                    return false;
+                }
+            }
+        } catch (error) {
+            const errorObjectString = JSON.stringify(error);
+            console.error(`Failure validating namespace exists: ${errorObjectString}`);
+            return undefined;
+        }
     }
 }

--- a/src/utilities/util.ts
+++ b/src/utilities/util.ts
@@ -454,10 +454,10 @@ async function promptForPassphrase(): Promise<string | undefined> {
 	});
 }
 
-export async function generateProjectDropDown(): Promise<string | undefined> {
+export async function generateProjectDropDown(nslist?: Array<string>): Promise<string | undefined> {
 	const args: Array<string> = [];
 	const k8s = new KubernetesObj();
-	const namespaceList = await k8s.getNamespaceList();
+	const namespaceList = nslist ? nslist : await k8s.getNamespaceList();
 	if (namespaceList) {
 		const namespaceSelection = await vscode.window.showQuickPick(namespaceList, {
 			canPickMany: false,


### PR DESCRIPTION
Namespace validation with warnings cannot occur during the creation of `kubernetesObj` or `kubernetesContext`. See bug #39 for more info. It has to come before or after. I put a validation step before, and if the project doesn't exist it shows a warning message and generates the project dropdown for them to change projects.