### PR TITLE
Enhanced Linter name matching fix

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -789,7 +789,7 @@ async function updateDiagnostics(document: vscode.TextDocument, collection: vsco
 					});
 				}
 			}
-			if((galaxyConfig.name && operatorConfig.name) && galaxyConfig.name.toLowerCase().replace('_','-') !== operatorConfig.name.toLowerCase().replace('_','-')){
+			if((galaxyConfig.name && operatorConfig.name) && galaxyConfig.name.toLowerCase().replace(/_/g,'-') !== operatorConfig.name.toLowerCase().replace(/_/g,'-')){
 				//Get name symbol
 				const nameSymbol : vscode.DocumentSymbol | undefined = docSymbols.find( (symbol: vscode.DocumentSymbol) => (symbol.name === 'name' && symbol.detail === operatorConfig.name));
 				if(nameSymbol){


### PR DESCRIPTION
A flaw was found in the previously merged enhanced linter, the operator config and galaxy yaml name matching use the javascript replace function with a string based search string, this made the replace function only replace the first occurrence causing an incorrect linter diagnostic. According to the javascript String.replace function documentation:

`If pattern is a string, only the first occurrence will be replaced. `
`To perform a global search and replace, use a regular expression with the g flag` 

This PR fixes this flaw by making the replace function search pattern string a regexp with the g flag set.