### PR TITLE
Addded install dependency step for OcSDK

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -31,7 +31,7 @@ import { OcSdkCommand } from "./shellCommands/ocSdkCommands";
 import { Session } from "./utilities/session";
 import { OperatorConfig } from "./linter/models";
 import { AnsibleGalaxyYmlSchema } from "./linter/galaxy";
-import {getLinterSettings, LinterSettings} from "./utilities/util";
+import { getLinterSettings, LinterSettings } from "./utilities/util";
 import * as yaml from "js-yaml";
 
 export async function activate(context: vscode.ExtensionContext) {
@@ -40,7 +40,9 @@ export async function activate(context: vscode.ExtensionContext) {
   initResources(context);
 
   //Setup Linter
-  const linterEnabled = getLinterSettings(LinterSettings.lintingEnabled) as string;
+  const linterEnabled = getLinterSettings(
+    LinterSettings.lintingEnabled,
+  ) as string;
   if (linterEnabled) {
     const collection = vscode.languages.createDiagnosticCollection("linter");
     if (vscode.window.activeTextEditor) {
@@ -256,6 +258,9 @@ function installOcSdk(
       vscode.window.showInformationMessage(
         "Installing the IBM Operator Collection SDK",
       );
+
+      await ocSdkCmd.installOcSDKDependencies(outputChannel, logPath);
+
       ocSdkCmd
         .installOcSDKCommand(outputChannel, logPath)
         .then(() => {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -454,9 +454,10 @@ function executeOpenLinkCommand(command: string): vscode.Disposable {
         typeof args === "string"
           ? vscode.Uri.parse(args)
           : vscode.Uri.parse(args.link);
-      let res = await vscode.env.openExternal(linkUri);
-      if (!res) {
-        vscode.window.showErrorMessage("Failure opening external link");
+      try {
+        await vscode.env.openExternal(linkUri);
+      } catch (e) {
+        vscode.window.showErrorMessage(`Failure opening external link: ${e}`);
       }
     },
   );

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1012,22 +1012,25 @@ async function updateDiagnostics(
                 "vscode.executeDocumentSymbolProvider",
                 playbookDoc.uri,
               )) as vscode.DocumentSymbol[];
-              let plays: vscode.DocumentSymbol[] = [];
-              playbookDocSymbols.forEach((symbol) => {
-                const play = symbol.children.find(
-                  (childSymbol) => childSymbol.name === "hosts",
-                );
-                if (play) {
-                  plays.push(play);
-                }
-              });
-              if (plays.some((play) => play.detail !== "all")) {
-                if (resourcePlaybookSymbol) {
-                  diagnostics.push({
-                    range: resourcePlaybookSymbol.range,
-                    message: `Playbook MUST use a "hosts: all" value. - ${resource.playbook}`,
-                    severity: vscode.DiagnosticSeverity.Error,
-                  });
+              if (playbookDocSymbols !== undefined) {
+                let plays: vscode.DocumentSymbol[] = [];
+
+                playbookDocSymbols.forEach((symbol) => {
+                  const play = symbol.children.find(
+                    (childSymbol) => childSymbol.name === "hosts",
+                  );
+                  if (play) {
+                    plays.push(play);
+                  }
+                });
+                if (plays.some((play) => play.detail !== "all")) {
+                  if (resourcePlaybookSymbol) {
+                    diagnostics.push({
+                      range: resourcePlaybookSymbol.range,
+                      message: `Playbook MUST use a "hosts: all" value. - ${resource.playbook}`,
+                      severity: vscode.DiagnosticSeverity.Error,
+                    });
+                  }
                 }
               }
             } catch (err) {

--- a/src/shellCommands/ocSdkCommands.ts
+++ b/src/shellCommands/ocSdkCommands.ts
@@ -138,6 +138,7 @@ export class OcSdkCommand {
     );
 
     if (statusCode !== 0) {
+      // pip is not installed
       pipVersion = "pip3";
       statusCode = await this.run(
         pipVersion,
@@ -147,6 +148,7 @@ export class OcSdkCommand {
       );
 
       if (statusCode !== 0) {
+        // pip3 is not installed
         pipVersion = "";
       }
     }

--- a/src/shellCommands/ocSdkCommands.ts
+++ b/src/shellCommands/ocSdkCommands.ts
@@ -120,7 +120,7 @@ export class OcSdkCommand {
    * the collection is not already installed
    * @param outputChannel - The VS Code output channel to display command output
    * @param logPath - Log path to store command output
-   * @returns - A Promise containing the return code of the command being executed
+   * @returns - A Promise containing a boolean signaling the success or failure of the command
    */
   async installOcSDKDependencies(
     outputChannel?: vscode.OutputChannel,

--- a/src/shellCommands/ocSdkCommands.ts
+++ b/src/shellCommands/ocSdkCommands.ts
@@ -130,25 +130,14 @@ export class OcSdkCommand {
     logPath?: string,
   ): Promise<string> {
     let pipVersion = "pip";
-    let statusCode = await this.run(
-      pipVersion,
-      ["--version"],
-      outputChannel,
-      logPath,
-    );
-
-    if (statusCode !== 0) {
-      // pip is not installed
-      pipVersion = "pip3";
-      statusCode = await this.run(
-        pipVersion,
-        ["--version"],
-        outputChannel,
-        logPath,
-      );
-
-      if (statusCode !== 0) {
-        // pip3 is not installed
+    try {
+      await this.run(pipVersion, ["--version"], outputChannel, logPath);
+    } catch (e) {
+      try {
+        // pip is not installed
+        pipVersion = "pip3";
+        await this.run(pipVersion, ["--version"], outputChannel, logPath);
+      } catch (e) {
         pipVersion = "";
       }
     }


### PR DESCRIPTION
- Added dependency check for `kubernetes.core` collection. 
- If the check fails, installs `kubernetes.core` collection and the `kubernetes` python module
- Added bug fix for #16, when you click copy link there is no failure message

Branch created from [galaxy-api](https://github.com/IBM/operator-collection-sdk-vscode-extension/tree/galaxy-api) branch so this is to be merged after.