### PR TITLE
Ocsdk version - incorporating About view

### DIFF
--- a/package.json
+++ b/package.json
@@ -191,6 +191,10 @@
         {
           "id": "operator-collection-sdk.openshiftClusterInfo",
           "name": "OpenShift Cluster Info"
+        },
+        {
+          "id": "operator-collection-sdk.about",
+          "name": "About"
         }
       ]
     },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -31,8 +31,9 @@ import { OcSdkCommand } from "./shellCommands/ocSdkCommands";
 import { Session } from "./utilities/session";
 import { OperatorConfig } from "./linter/models";
 import { AnsibleGalaxyYmlSchema } from "./linter/galaxy";
-import {getLinterSettings, LinterSettings} from "./utilities/util";
+import { getLinterSettings, LinterSettings } from "./utilities/util";
 import * as yaml from "js-yaml";
+import { AboutTreeProvider } from "./treeViews/providers/aboutProvider";
 
 export async function activate(context: vscode.ExtensionContext) {
   // Set context as a global as some tests depend on it
@@ -40,7 +41,9 @@ export async function activate(context: vscode.ExtensionContext) {
   initResources(context);
 
   //Setup Linter
-  const linterEnabled = getLinterSettings(LinterSettings.lintingEnabled) as string;
+  const linterEnabled = getLinterSettings(
+    LinterSettings.lintingEnabled,
+  ) as string;
   if (linterEnabled) {
     const collection = vscode.languages.createDiagnosticCollection("linter");
     if (vscode.window.activeTextEditor) {
@@ -80,6 +83,7 @@ export async function activate(context: vscode.ExtensionContext) {
   const operatorTreeProvider = new OperatorsTreeProvider(session);
   const resourceTreeProvider = new ResourcesTreeProvider(session);
   const openshiftTreeProvider = new OpenShiftTreeProvider(session);
+  const aboutProvider = new AboutTreeProvider(session);
   const linksTreeProvider = new LinksTreeProvider();
   const containerLogProvider = new ContainerLogProvider(session);
   const verboseContainerLogProvider = new VerboseContainerLogProvider(session);
@@ -101,6 +105,7 @@ export async function activate(context: vscode.ExtensionContext) {
     VSCodeViewIds.openshiftClusterInfo,
     openshiftTreeProvider,
   );
+  vscode.window.registerTreeDataProvider(VSCodeViewIds.about, aboutProvider);
   vscode.workspace.registerTextDocumentContentProvider(
     util.logScheme,
     containerLogProvider,
@@ -195,6 +200,7 @@ export async function activate(context: vscode.ExtensionContext) {
     vscode.commands.registerCommand(VSCodeCommands.refresh, () => {
       operatorTreeProvider.refresh();
       resourceTreeProvider.refresh();
+      aboutProvider.refresh();
     }),
   );
   context.subscriptions.push(

--- a/src/shellCommands/ocSdkCommands.ts
+++ b/src/shellCommands/ocSdkCommands.ts
@@ -169,7 +169,9 @@ export class OcSdkCommand {
     ];
 
     let setVersionInstalled = (outputValue: string) => {
-      versionInstalled = outputValue.split(" ")?.[1]; // item in [1] is the version
+      versionInstalled = outputValue.split(" ")?.filter((item) => {
+        return item.length;
+      })?.[1]; // item in [1] is the version
     };
 
     await this.run(cmd, args, outputChannel, logPath, setVersionInstalled);

--- a/src/shellCommands/ocSdkCommands.ts
+++ b/src/shellCommands/ocSdkCommands.ts
@@ -8,7 +8,10 @@ import * as child_process from "child_process";
 import * as fs from "fs-extra";
 import * as https from "https";
 import * as http from "http";
-import {getAnsibleGalaxySettings, AnsibleGalaxySettings} from "../utilities/util";
+import {
+  getAnsibleGalaxySettings,
+  AnsibleGalaxySettings,
+} from "../utilities/util";
 
 type HTTP = typeof http;
 type HTTPS = typeof https;
@@ -94,8 +97,12 @@ export class OcSdkCommand {
     outputChannel?: vscode.OutputChannel,
     logPath?: string,
   ): Promise<string> {
-    const galaxyUrl = getAnsibleGalaxySettings(AnsibleGalaxySettings.ansibleGalaxyURL) as string;
-    const galaxyNamespace = getAnsibleGalaxySettings(AnsibleGalaxySettings.ansibleGalaxyNamespace) as string;
+    const galaxyUrl = getAnsibleGalaxySettings(
+      AnsibleGalaxySettings.ansibleGalaxyURL,
+    ) as string;
+    const galaxyNamespace = getAnsibleGalaxySettings(
+      AnsibleGalaxySettings.ansibleGalaxyNamespace,
+    ) as string;
     const cmd: string = "ansible-galaxy";
     let args: Array<string> = [
       "collection",
@@ -118,8 +125,12 @@ export class OcSdkCommand {
     logPath?: string,
   ): Promise<string> {
     // ansible-galaxy collection install ibm.operator_collection_sdk
-    const galaxyUrl = getAnsibleGalaxySettings(AnsibleGalaxySettings.ansibleGalaxyURL) as string;
-    const galaxyNamespace = getAnsibleGalaxySettings(AnsibleGalaxySettings.ansibleGalaxyNamespace) as string;
+    const galaxyUrl = getAnsibleGalaxySettings(
+      AnsibleGalaxySettings.ansibleGalaxyURL,
+    ) as string;
+    const galaxyNamespace = getAnsibleGalaxySettings(
+      AnsibleGalaxySettings.ansibleGalaxyNamespace,
+    ) as string;
     const cmd: string = "ansible-galaxy";
     let args: Array<string> = [
       "collection",
@@ -133,19 +144,19 @@ export class OcSdkCommand {
   }
 
   /**
-   * Determinate if the installed local collection is the same as the latest collection in galaxy server
+   * Determinate local collection sdk version
    * @param outputChannel - The VS Code output channel to display command output
    * @param logPath - Log path to store command output
    * @returns - A Promise container the return code of the command being executed
    */
-  async runDeterminateOcSdkIsOutdated(
+  async runOcSdkVersion(
     outputChannel?: vscode.OutputChannel,
     logPath?: string,
-  ): Promise<boolean> {
-    const galaxyUrl = getAnsibleGalaxySettings(AnsibleGalaxySettings.ansibleGalaxyURL) as string;
-    const galaxyNamespace = getAnsibleGalaxySettings(AnsibleGalaxySettings.ansibleGalaxyNamespace) as string;
-    let versionInstalled = "";
-    let latestVersion: string | undefined;
+  ): Promise<string> {
+    const galaxyNamespace = getAnsibleGalaxySettings(
+      AnsibleGalaxySettings.ansibleGalaxyNamespace,
+    ) as string;
+    let versionInstalled: string;
 
     // ansible-galaxy collection list | grep ibm.operator_collection_sdk
     const cmd: string = "ansible-galaxy";
@@ -157,6 +168,33 @@ export class OcSdkCommand {
       `${galaxyNamespace}.operator_collection_sdk`,
     ];
 
+    let setVersionInstalled = (outputValue: string) => {
+      versionInstalled = outputValue.split(" ")?.[1]; // item in [1] is the version
+    };
+
+    await this.run(cmd, args, outputChannel, logPath, setVersionInstalled);
+    return new Promise<string>((resolve) => {
+      resolve(versionInstalled);
+    });
+  }
+
+  /**
+   * Determinate if the installed local collection is the same as the latest collection in galaxy server
+   * @param outputChannel - The VS Code output channel to display command output
+   * @param logPath - Log path to store command output
+   * @returns - A Promise container the return code of the command being executed
+   */
+  async runDeterminateOcSdkIsOutdated(
+    outputChannel?: vscode.OutputChannel,
+    logPath?: string,
+  ): Promise<boolean> {
+    const galaxyUrl = getAnsibleGalaxySettings(
+      AnsibleGalaxySettings.ansibleGalaxyURL,
+    ) as string;
+    const galaxyNamespace = getAnsibleGalaxySettings(
+      AnsibleGalaxySettings.ansibleGalaxyNamespace,
+    ) as string;
+
     let jsonData: any;
     try {
       jsonData = await getJsonData(galaxyUrl, galaxyNamespace);
@@ -165,14 +203,10 @@ export class OcSdkCommand {
         `Failure retrieving data from Ansible Galaxy: ${e}`,
       );
     }
-   
-    latestVersion = getLatestCollectionVersion(jsonData);
 
-    let setVersionInstalled = (outputValue: string) => {
-      versionInstalled = outputValue.split(" ")?.[1]; // item in [1] is the version
-    };
+    const latestVersion = getLatestCollectionVersion(jsonData);
+    const versionInstalled = await this.runOcSdkVersion(outputChannel, logPath);
 
-    await this.run(cmd, args, outputChannel, logPath, setVersionInstalled);
     return new Promise<boolean>((resolve, reject) => {
       if (latestVersion === undefined) {
         reject("Unable to locate latest version");
@@ -193,8 +227,12 @@ export class OcSdkCommand {
     logPath?: string,
   ): Promise<boolean> {
     // ansible-galaxy collection install ibm.operator_collection_sdk --upgrade
-    const galaxyUrl = getAnsibleGalaxySettings(AnsibleGalaxySettings.ansibleGalaxyURL) as string;
-    const galaxyNamespace = getAnsibleGalaxySettings(AnsibleGalaxySettings.ansibleGalaxyNamespace) as string;
+    const galaxyUrl = getAnsibleGalaxySettings(
+      AnsibleGalaxySettings.ansibleGalaxyURL,
+    ) as string;
+    const galaxyNamespace = getAnsibleGalaxySettings(
+      AnsibleGalaxySettings.ansibleGalaxyNamespace,
+    ) as string;
     const cmd: string = "ansible-galaxy";
     let args: Array<string> = [
       "collection",
@@ -294,48 +332,50 @@ export class OcSdkCommand {
   }
 }
 
-
-async function getJsonData(galaxyUrl: string, galaxyNamespace: string): Promise<any> {
-  const apiUrl =  `${galaxyUrl}/api/v3/plugin/ansible/content/published/collections/index/${galaxyNamespace}/operator_collection_sdk/versions/`;
+async function getJsonData(
+  galaxyUrl: string,
+  galaxyNamespace: string,
+): Promise<any> {
+  const apiUrl = `${galaxyUrl}/api/v3/plugin/ansible/content/published/collections/index/${galaxyNamespace}/operator_collection_sdk/versions/`;
   const legacyApiUrl = `${galaxyUrl}/api/internal/ui/repo-or-collection-detail/?namespace=${galaxyNamespace}&name=operator_collection_sdk`;
   const galaxyResponse = getRequest(apiUrl);
   const legacyGalaxyResponse = getRequest(legacyApiUrl);
-  return Promise.all([galaxyResponse, legacyGalaxyResponse]).then((responses) => {
-    if (responses[0] !== undefined) {
-      return responses[0];
-    }
-    if (responses[1] !== undefined) {
-      return responses[1];
-    }
-    return undefined; 
-  }).catch((e) => {
-    return e;
-  });
+  return Promise.all([galaxyResponse, legacyGalaxyResponse])
+    .then((responses) => {
+      if (responses[0] !== undefined) {
+        return responses[0];
+      }
+      if (responses[1] !== undefined) {
+        return responses[1];
+      }
+      return undefined;
+    })
+    .catch((e) => {
+      return e;
+    });
 }
 
 async function getRequest(apiUrl: string): Promise<string | undefined> {
   const urlScheme = vscode.Uri.parse(apiUrl).scheme;
-  const httpType: HTTP | HTTPS = urlScheme === "https" ? require("https") : require("http");
+  const httpType: HTTP | HTTPS =
+    urlScheme === "https" ? require("https") : require("http");
   return new Promise<string | undefined>((resolve, reject) => {
     httpType
-      .get(
-        apiUrl,
-        (resp) => {
-          let data = "";
-          resp.on("data", (chunk) => {
-            data += chunk;
+      .get(apiUrl, (resp) => {
+        let data = "";
+        resp.on("data", (chunk) => {
+          data += chunk;
+        });
+        if (resp.statusCode === 200) {
+          resp.on("end", () => {
+            resolve(JSON.parse(data));
           });
-          if (resp.statusCode === 200) {
-            resp.on("end", () => {
-              resolve(JSON.parse(data));
-            });
-          } else {
-            resp.on("end", () => {
-              resolve(undefined);
-            });
-          }
-        },
-      )
+        } else {
+          resp.on("end", () => {
+            resolve(undefined);
+          });
+        }
+      })
       .on("error", (err) => {
         reject(err);
       });
@@ -343,5 +383,8 @@ async function getRequest(apiUrl: string): Promise<string | undefined> {
 }
 
 function getLatestCollectionVersion(jsonData: any): string | undefined {
-  return jsonData?.data?.collection?.latest_version?.version ?? jsonData?.data[0]?.version;
+  return (
+    jsonData?.data?.collection?.latest_version?.version ??
+    jsonData?.data[0]?.version
+  );
 }

--- a/src/treeViews/providers/aboutProvider.ts
+++ b/src/treeViews/providers/aboutProvider.ts
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2023 IBM Inc. All rights reserved
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as vscode from "vscode";
+import { Session } from "../../utilities/session";
+
+type TreeItem = vscode.TreeItem | undefined | void;
+
+export class AboutTreeProvider
+  implements vscode.TreeDataProvider<vscode.TreeItem>
+{
+  private _onDidChangeTreeData: vscode.EventEmitter<TreeItem> =
+    new vscode.EventEmitter<TreeItem>();
+  readonly onDidChangeTreeData: vscode.Event<TreeItem> =
+    this._onDidChangeTreeData.event;
+
+  constructor(private readonly session: Session) {}
+
+  refresh(): void {
+    this._onDidChangeTreeData.fire();
+  }
+
+  getTreeItem(element: vscode.TreeItem): vscode.TreeItem {
+    return element;
+  }
+
+  getChildren(element?: vscode.TreeItem): Promise<vscode.TreeItem[]> {
+    const items: Array<vscode.TreeItem> = [];
+    const ocSdkVersionInstalled = this.session.ocSdkVersion();
+    return Promise.all([ocSdkVersionInstalled]).then((values) => {
+      if (!element) {
+        items.push(
+          new vscode.TreeItem(
+            `Operator Collection SDK v${values[0]}`,
+            vscode.TreeItemCollapsibleState.None,
+          ),
+        );
+      }
+      return items;
+    });
+  }
+}

--- a/src/treeViews/providers/aboutProvider.ts
+++ b/src/treeViews/providers/aboutProvider.ts
@@ -5,6 +5,7 @@
 
 import * as vscode from "vscode";
 import { Session } from "../../utilities/session";
+import { getBrokerIconPath } from "../../utilities/util";
 
 type TreeItem = vscode.TreeItem | undefined | void;
 
@@ -31,12 +32,15 @@ export class AboutTreeProvider
     const ocSdkVersionInstalled = this.session.ocSdkVersion();
     return Promise.all([ocSdkVersionInstalled]).then((values) => {
       if (!element) {
-        items.push(
-          new vscode.TreeItem(
-            `Operator Collection SDK v${values[0]}`,
-            vscode.TreeItemCollapsibleState.None,
-          ),
+        const ocsdkVersionItem = new vscode.TreeItem(
+          `Operator Collection SDK v${values[0]}`,
+          vscode.TreeItemCollapsibleState.None,
         );
+        ocsdkVersionItem.iconPath = {
+          light: getBrokerIconPath("light"),
+          dark: getBrokerIconPath("dark"),
+        };
+        items.push(ocsdkVersionItem);
       }
       return items;
     });

--- a/src/utilities/commandConstants.ts
+++ b/src/utilities/commandConstants.ts
@@ -35,6 +35,7 @@ export enum VSCodeViewIds {
   resources = "operator-collection-sdk.resources",
   help = "operator-collection-sdk.help",
   openshiftClusterInfo = "operator-collection-sdk.openshiftClusterInfo",
+  about = "operator-collection-sdk.about",
 }
 
 export enum CustomResourcePhases {

--- a/src/utilities/session.ts
+++ b/src/utilities/session.ts
@@ -6,7 +6,10 @@
 import * as vscode from "vscode";
 import { OcSdkCommand } from "../shellCommands/ocSdkCommands";
 import { KubernetesContext } from "../kubernetes/kubernetesContext";
-import { getAnsibleGalaxySettings, AnsibleGalaxySettings } from "../utilities/util";
+import {
+  getAnsibleGalaxySettings,
+  AnsibleGalaxySettings,
+} from "../utilities/util";
 
 export class Session {
   public ocSdkInstalled: boolean = false;
@@ -22,7 +25,9 @@ export class Session {
    * @returns - A promise containing a boolean, returning true if the IBM Operator Collection SDK is installed
    */
   async validateOcSDKInstallation(): Promise<boolean> {
-    const ansibleGalaxyConnectivity = getAnsibleGalaxySettings(AnsibleGalaxySettings.ansibleGalaxyConnectivity) as boolean;
+    const ansibleGalaxyConnectivity = getAnsibleGalaxySettings(
+      AnsibleGalaxySettings.ansibleGalaxyConnectivity,
+    ) as boolean;
     if (!ansibleGalaxyConnectivity) {
       this.ocSdkInstalled = true;
       return true;
@@ -34,10 +39,19 @@ export class Session {
     } catch (e) {
       console.log("Install the IBM Operator Collection SDK use this extension");
       // vscode.window.showWarningMessage("Install the IBM Operator Collection SDK Ansible collection to use the IBM Operator Collection SDK extension");
-      
+
       this.ocSdkInstalled = false;
       return false;
     }
+  }
+
+  /**
+   * Determinate installed IBM Operator Collection SDK version
+   * @returns - A promise containing a string, returning the installed IBM Operator Collection SDK version
+   */
+  async ocSdkVersion(): Promise<string> {
+    const version = await this.ocSdkCmd.runOcSdkVersion();
+    return version;
   }
 
   /**
@@ -45,7 +59,9 @@ export class Session {
    * @returns - A promise containing a boolean, returning true if the installed IBM Operator Collection SDK can be updated to a newer version
    */
   async determinateOcSdkIsOutdated(): Promise<boolean> {
-    const ansibleGalaxyConnectivity = getAnsibleGalaxySettings(AnsibleGalaxySettings.ansibleGalaxyConnectivity) as boolean;
+    const ansibleGalaxyConnectivity = getAnsibleGalaxySettings(
+      AnsibleGalaxySettings.ansibleGalaxyConnectivity,
+    ) as boolean;
     if (!ansibleGalaxyConnectivity) {
       this.ocSdkOutdated = false;
       return false;

--- a/src/utilities/util.ts
+++ b/src/utilities/util.ts
@@ -689,27 +689,44 @@ export function parseCustomResourceUri(uri: vscode.Uri): {
 }
 
 export async function sleep(ms: number): Promise<void> {
-    return new Promise((resolve) => setTimeout(resolve, ms));
+  return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
 export function getAnsibleGalaxySettings(property: string): any {
-  const configuration = vscode.workspace.getConfiguration("operatorCollectionSdk.ansibleGalaxy");
+  const configuration = vscode.workspace.getConfiguration(
+    "operatorCollectionSdk.ansibleGalaxy",
+  );
   const setting = configuration.get(property);
   if (setting instanceof String && setting === "") {
     switch (property) {
       case AnsibleGalaxySettings.ansibleGalaxyNamespace: {
         return AnsibleGalaxySettingsDefaults.ansibleGalaxyNamespace;
-      } 
+      }
       case AnsibleGalaxySettings.ansibleGalaxyURL: {
         return AnsibleGalaxySettingsDefaults.ansibleGalaxyURL;
-      } 
+      }
     }
   } else {
     return setting;
-  } 
+  }
 }
 
 export function getLinterSettings(property: string): any {
-  const configuration = vscode.workspace.getConfiguration("operatorCollectionSdk.linter");
+  const configuration = vscode.workspace.getConfiguration(
+    "operatorCollectionSdk.linter",
+  );
   return configuration.get(property);
+}
+
+export function getBrokerIconPath(theme: string): string {
+  const path = require("path");
+  return path.join(
+    __filename,
+    "..",
+    "..",
+    "resources",
+    "icons",
+    theme,
+    "broker.png",
+  );
 }


### PR DESCRIPTION
This PR is adding the "About" view and displaying the local ocsdk version installed, addressing issue #8 

some of the reflected changes are reformatting previous code, this might be because not all contributors have ran `npm install` after "prettier" the formatting tool was merged.