### PR TITLE
Prompt user to login when OCP token expires

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,6 +100,12 @@
         "icon": "$(extensions-refresh)"
       },
       {
+        "command": "operator-collection-sdk.refreshAll",
+        "title": "Refresh",
+        "category": "OC-SDK",
+        "icon": "$(extensions-refresh)"
+      },
+      {
         "command": "operator-collection-sdk.resourceRefresh",
         "title": "Refresh",
         "category": "OC-SDK",
@@ -233,7 +239,7 @@
     "menus": {
       "view/title": [
         {
-          "command": "operator-collection-sdk.refresh",
+          "command": "operator-collection-sdk.refreshAll",
           "when": "view == operator-collection-sdk.operators",
           "group": "navigation"
         },
@@ -243,7 +249,7 @@
           "group": "navigation"
         },
         {
-          "command": "operator-collection-sdk.refreshOpenShiftInfo",
+          "command": "operator-collection-sdk.refreshAll",
           "when": "view == operator-collection-sdk.openshiftClusterInfo",
           "group": "navigation"
         }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -175,13 +175,13 @@ export async function activate(context: vscode.ExtensionContext) {
     ),
   );
   context.subscriptions.push(
-    deleteCustomResource(VSCodeCommands.deleteCustomResource),
+    deleteCustomResource(VSCodeCommands.deleteCustomResource, session),
   );
   context.subscriptions.push(
-    executeContainerViewLogCommand(VSCodeCommands.viewLogs),
+    executeContainerViewLogCommand(VSCodeCommands.viewLogs, session),
   );
   context.subscriptions.push(
-    executeContainerViewLogCommand(VSCodeCommands.viewVerboseLogs),
+    executeContainerViewLogCommand(VSCodeCommands.viewVerboseLogs, session),
   );
   context.subscriptions.push(
     executeOpenLinkCommand(VSCodeCommands.openEditLink),
@@ -190,7 +190,7 @@ export async function activate(context: vscode.ExtensionContext) {
     executeOpenLinkCommand(VSCodeCommands.openAddLink),
   );
   context.subscriptions.push(executeOpenLinkCommand(VSCodeCommands.openLink));
-  context.subscriptions.push(viewResourceCommand(VSCodeCommands.viewResource));
+  context.subscriptions.push(viewResourceCommand(VSCodeCommands.viewResource, session));
   context.subscriptions.push(
     vscode.commands.registerCommand(VSCodeCommands.refresh, () => {
       operatorTreeProvider.refresh();
@@ -199,19 +199,41 @@ export async function activate(context: vscode.ExtensionContext) {
   );
   context.subscriptions.push(
     vscode.commands.registerCommand(VSCodeCommands.resourceRefresh, () => {
-      resourceTreeProvider.refresh();
+      session.update().then((proceed) => {
+        if (proceed) {
+          resourceTreeProvider.refresh();
+        }
+      }).catch((e) => {
+        vscode.window.showErrorMessage(
+          `Failure updating session: ${e}`,
+        );
+      });
     }),
   );
   context.subscriptions.push(
     vscode.commands.registerCommand(VSCodeCommands.refreshAll, () => {
-      openshiftTreeProvider.refresh();
-      operatorTreeProvider.refresh();
-      resourceTreeProvider.refresh();
+      session.update(true).then(() => {
+        openshiftTreeProvider.refresh();
+        operatorTreeProvider.refresh();
+        resourceTreeProvider.refresh();
+      }).catch((e) => {
+        vscode.window.showErrorMessage(
+          `Failure updating session: ${e}`,
+        );
+      });
     }),
   );
   context.subscriptions.push(
     vscode.commands.registerCommand(VSCodeCommands.refreshOpenShiftInfo, () => {
-      openshiftTreeProvider.refresh();
+      session.update().then((proceed) => {
+        if (proceed) {
+          openshiftTreeProvider.refresh();
+        }
+      }).catch((e) => {
+        vscode.window.showErrorMessage(
+          `Failure updating session: ${e}`,
+        );
+      });
     }),
   );
   context.subscriptions.push(
@@ -331,32 +353,40 @@ function updateProject(
         return;
       }
 
-      const k8s = new KubernetesObj();
-      let namespace: string | undefined;
-      if (arg.description === k8s.namespace) {
-        // implies that the edit button was selected in the editor
-        namespace = await util.generateProjectDropDown();
-      } else {
-        // allows for tests to pass in new namespace directly
-        namespace = arg.description;
-      }
+      session.update().then(async (proceed) => {
+        if (proceed) {
+          const k8s = new KubernetesObj();
+          let namespace: string | undefined;
+          if (arg.description === k8s.namespace) {
+            // implies that the edit button was selected in the editor
+            namespace = await util.generateProjectDropDown();
+          } else {
+            // allows for tests to pass in new namespace directly
+            namespace = arg.description;
+          }
 
-      if (namespace) {
-        ocCmd
-          .runOcProjectCommand(namespace, outputChannel, logPath)
-          .then(() => {
-            vscode.window.showInformationMessage(
-              "Successfully updating Project on OpenShift cluster",
-            );
-            vscode.commands.executeCommand(VSCodeCommands.refreshAll);
-          })
-          .catch((e) => {
-            vscode.window.showErrorMessage(
-              `Failure updating Project on OpenShift cluster: ${e}`,
-            );
-          });
-      }
-    },
+          if (namespace) {
+            ocCmd
+              .runOcProjectCommand(namespace, outputChannel, logPath)
+              .then(() => {
+                vscode.window.showInformationMessage(
+                  "Successfully updating Project on OpenShift cluster",
+                );
+                vscode.commands.executeCommand(VSCodeCommands.refreshAll);
+              })
+              .catch((e) => {
+                vscode.window.showErrorMessage(
+                  `Failure updating Project on OpenShift cluster: ${e}`,
+                );
+              });
+          }
+        }
+      }).catch((e) => {
+        vscode.window.showErrorMessage(
+          `Failure updating session: ${e}`,
+        );
+      });
+    }
   );
 }
 
@@ -457,127 +487,144 @@ function executeOpenLinkCommand(command: string): vscode.Disposable {
   );
 }
 
-function viewResourceCommand(command: string): vscode.Disposable {
+function viewResourceCommand(command: string, session: Session): vscode.Disposable {
   return vscode.commands.registerCommand(
     command,
     async (args: CustomResources) => {
-      let kind: string;
-      let instanceName: string;
-      let group: string;
-      let apiVersion: string;
-      if (args instanceof ZosEndpointsItem) {
-        kind = args.zosendpointObj.kind;
-        instanceName = args.zosendpointObj.metadata.name;
-        group = args.zosendpointObj.apiVersion.split("/")[0];
-        apiVersion = args.zosendpointObj.apiVersion.split("/")[1];
-      } else if (args instanceof SubOperatorConfigsItem) {
-        kind = args.subOperatorConfigObj.kind;
-        instanceName = args.subOperatorConfigObj.metadata.name;
-        group = args.subOperatorConfigObj.apiVersion.split("/")[0];
-        apiVersion = args.subOperatorConfigObj.apiVersion.split("/")[1];
-      } else if (args instanceof OperatorCollectionsItem) {
-        kind = args.operatorCollectionObj.kind;
-        instanceName = args.operatorCollectionObj.metadata.name;
-        group = args.operatorCollectionObj.apiVersion.split("/")[0];
-        apiVersion = args.operatorCollectionObj.apiVersion.split("/")[1];
-      } else if (args instanceof CustomResourcesItem) {
-        kind = args.customResourceObj.kind;
-        instanceName = args.customResourceObj.metadata.name;
-        group = args.customResourceObj.apiVersion.split("/")[0];
-        apiVersion = args.customResourceObj.apiVersion.split("/")[1];
-      } else {
+      session.update().then(async (proceed) => {
+        if (proceed) {
+          let kind: string;
+          let instanceName: string;
+          let group: string;
+          let apiVersion: string;
+          if (args instanceof ZosEndpointsItem) {
+            kind = args.zosendpointObj.kind;
+            instanceName = args.zosendpointObj.metadata.name;
+            group = args.zosendpointObj.apiVersion.split("/")[0];
+            apiVersion = args.zosendpointObj.apiVersion.split("/")[1];
+          } else if (args instanceof SubOperatorConfigsItem) {
+            kind = args.subOperatorConfigObj.kind;
+            instanceName = args.subOperatorConfigObj.metadata.name;
+            group = args.subOperatorConfigObj.apiVersion.split("/")[0];
+            apiVersion = args.subOperatorConfigObj.apiVersion.split("/")[1];
+          } else if (args instanceof OperatorCollectionsItem) {
+            kind = args.operatorCollectionObj.kind;
+            instanceName = args.operatorCollectionObj.metadata.name;
+            group = args.operatorCollectionObj.apiVersion.split("/")[0];
+            apiVersion = args.operatorCollectionObj.apiVersion.split("/")[1];
+          } else if (args instanceof CustomResourcesItem) {
+            kind = args.customResourceObj.kind;
+            instanceName = args.customResourceObj.metadata.name;
+            group = args.customResourceObj.apiVersion.split("/")[0];
+            apiVersion = args.customResourceObj.apiVersion.split("/")[1];
+          } else {
+            vscode.window.showErrorMessage(
+              "Unable to preview resource for invalid resource type",
+            );
+            return;
+          }
+          const uri = util.buildCustomResourceUri(
+            kind!,
+            instanceName!,
+            group!,
+            apiVersion!,
+          );
+          const doc = await vscode.workspace.openTextDocument(uri);
+          await vscode.window.showTextDocument(doc, { preview: false });
+        }
+      }).catch((e) => {
         vscode.window.showErrorMessage(
-          "Unable to preview resource for invalid resource type",
+          `Failure updating session: ${e}`,
         );
-        return;
-      }
-      const uri = util.buildCustomResourceUri(
-        kind!,
-        instanceName!,
-        group!,
-        apiVersion!,
-      );
-      const doc = await vscode.workspace.openTextDocument(uri);
-      await vscode.window.showTextDocument(doc, { preview: false });
-    },
+      });
+    }
   );
 }
 
-function executeContainerViewLogCommand(command: string): vscode.Disposable {
+function executeContainerViewLogCommand(command: string, session: Session): vscode.Disposable {
   return vscode.commands.registerCommand(
     command,
     async (containerItemArgs: OperatorContainerItem, logPath?: string) => {
-      if (containerItemArgs) {
-        const k8s = new KubernetesObj();
-        const pwd = util.getCurrentWorkspaceRootFolder();
-        if (!pwd) {
-          vscode.window.showErrorMessage(
-            "Unable to execute command when workspace is empty",
-          );
-        } else {
-          let workspacePath = await util.selectOperatorInWorkspace(
-            pwd,
-            containerItemArgs.parentOperator.operatorName,
-          );
-
-          if (!workspacePath) {
-            vscode.window.showErrorMessage(
-              "Unable to locate valid operator collection in workspace",
-            );
-          } else {
-            workspacePath = path.parse(workspacePath).dir;
-            switch (command) {
-              case VSCodeCommands.viewLogs: {
-                const logUri = util.buildContainerLogUri(
-                  containerItemArgs.podObj.metadata?.name!,
-                  containerItemArgs.containerStatus.name,
+      session.update().then(async (proceed) => {
+        if (proceed) {
+          if (containerItemArgs) {
+            const k8s = new KubernetesObj();
+            const pwd = util.getCurrentWorkspaceRootFolder();
+            if (!pwd) {
+              vscode.window.showErrorMessage(
+                "Unable to execute command when workspace is empty",
+              );
+            } else {
+              let workspacePath = await util.selectOperatorInWorkspace(
+                pwd,
+                containerItemArgs.parentOperator.operatorName,
+              );
+    
+              if (!workspacePath) {
+                vscode.window.showErrorMessage(
+                  "Unable to locate valid operator collection in workspace",
                 );
-                const doc = await vscode.workspace.openTextDocument(logUri);
-                await vscode.window.showTextDocument(doc, { preview: false });
-                break;
-              }
-              case VSCodeCommands.viewVerboseLogs: {
-                const apiVersion =
-                  await util.getConvertedApiVersion(workspacePath);
-                const kind =
-                  await util.selectCustomResourceFromOperatorInWorkspace(
-                    workspacePath,
-                  );
-                let crInstance: string | undefined = "";
-                if (apiVersion) {
-                  crInstance = await util.selectCustomResourceInstance(
-                    workspacePath,
-                    k8s,
-                    apiVersion,
-                    kind!,
-                  );
-                  if (kind && crInstance) {
-                    const logUri = util.buildVerboseContainerLogUri(
+              } else {
+                workspacePath = path.parse(workspacePath).dir;
+                switch (command) {
+                  case VSCodeCommands.viewLogs: {
+                    const logUri = util.buildContainerLogUri(
                       containerItemArgs.podObj.metadata?.name!,
                       containerItemArgs.containerStatus.name,
-                      apiVersion,
-                      kind,
-                      crInstance,
                     );
                     const doc = await vscode.workspace.openTextDocument(logUri);
-                    await vscode.window.showTextDocument(doc, {
-                      preview: false,
-                    });
+                    await vscode.window.showTextDocument(doc, { preview: false });
+                    break;
                   }
-                } else {
-                  vscode.window.showErrorMessage(
-                    "Unable to download log due to undefined version in operator-config",
-                  );
+                  case VSCodeCommands.viewVerboseLogs: {
+                    const apiVersion =
+                      await util.getConvertedApiVersion(workspacePath);
+                    const kind =
+                      await util.selectCustomResourceFromOperatorInWorkspace(
+                        workspacePath,
+                      );
+                    let crInstance: string | undefined = "";
+                    if (apiVersion) {
+                      crInstance = await util.selectCustomResourceInstance(
+                        workspacePath,
+                        k8s,
+                        apiVersion,
+                        kind!,
+                      );
+                      if (kind && crInstance) {
+                        const logUri = util.buildVerboseContainerLogUri(
+                          containerItemArgs.podObj.metadata?.name!,
+                          containerItemArgs.containerStatus.name,
+                          apiVersion,
+                          kind,
+                          crInstance,
+                        );
+                        const doc = await vscode.workspace.openTextDocument(logUri);
+                        await vscode.window.showTextDocument(doc, {
+                          preview: false,
+                        });
+                      }
+                    } else {
+                      vscode.window.showErrorMessage(
+                        "Unable to download log due to undefined version in operator-config",
+                      );
+                    }
+                  }
                 }
               }
             }
+          } else {
+            vscode.window.showInformationMessage(
+              "Please wait for the operator to finish loading, then try again.",
+            );
           }
         }
-      } else {
-        vscode.window.showInformationMessage(
-          "Please wait for the operator to finish loading, then try again.",
+        
+      }).catch((e) => {
+        vscode.window.showErrorMessage(
+          `Failure updating session: ${e}`,
         );
-      }
+      });
     },
   );
 }
@@ -595,99 +642,107 @@ function executeSimpleSdkCommand(
   return vscode.commands.registerCommand(
     command,
     async (operatorItemArg: OperatorItem, logPath?: string) => {
-      let workspacePath: string | undefined = "";
-      if (operatorItemArg) {
-        workspacePath = operatorItemArg.workspacePath;
-      } else {
-        let pwd = util.getCurrentWorkspaceRootFolder();
-        if (pwd) {
-          workspacePath = await util.selectOperatorInWorkspace(pwd);
-          workspacePath = path.parse(workspacePath!).dir;
-        }
-      }
-      if (workspacePath) {
-        const k8s = new KubernetesObj();
-        const validNamespace = await k8s.validateNamespaceExists();
-        if (validNamespace) {
-          session.operationPending = true;
-          let ocSdkCommand = new OcSdkCommand(workspacePath);
-          outputChannel?.show();
-          switch (command) {
-            case VSCodeCommands.deleteOperator: {
-              vscode.window.showInformationMessage(
-                "Delete Operator request in progress",
-              );
-              const poll = util.pollRun(10);
-              const runDeleteOperatorCommand =
-                ocSdkCommand.runDeleteOperatorCommand(outputChannel, logPath);
-              Promise.all([poll, runDeleteOperatorCommand])
-                .then(() => {
-                  session.operationPending = false;
-                  vscode.window.showInformationMessage(
-                    "Delete Operator command executed successfully",
-                  );
-                  vscode.commands.executeCommand(VSCodeCommands.refresh);
-                })
-                .catch((e) => {
-                  session.operationPending = false;
-                  vscode.window.showInformationMessage(
-                    `Failure executing Delete Operator command: RC ${e}`,
-                  );
-                });
-              break;
+      session.update().then(async (proceed) => {
+        if (proceed) {
+          let workspacePath: string | undefined = "";
+          if (operatorItemArg) {
+            workspacePath = operatorItemArg.workspacePath;
+          } else {
+            let pwd = util.getCurrentWorkspaceRootFolder();
+            if (pwd) {
+              workspacePath = await util.selectOperatorInWorkspace(pwd);
+              workspacePath = path.parse(workspacePath!).dir;
             }
-            case VSCodeCommands.redeployCollection: {
-              vscode.window.showInformationMessage(
-                "Redeploy Collection request in progress",
-              );
-              const poll = util.pollRun(30);
-              const runRedeployCollectionCommand =
-                ocSdkCommand.runRedeployCollectionCommand(
-                  outputChannel,
-                  logPath,
-                );
-              Promise.all([poll, runRedeployCollectionCommand])
-                .then(() => {
-                  session.operationPending = false;
+          }
+          if (workspacePath) {
+            const k8s = new KubernetesObj();
+            const validNamespace = await k8s.validateNamespaceExists();
+            if (validNamespace) {
+              session.operationPending = true;
+              let ocSdkCommand = new OcSdkCommand(workspacePath);
+              outputChannel?.show();
+              switch (command) {
+                case VSCodeCommands.deleteOperator: {
                   vscode.window.showInformationMessage(
-                    "Redeploy Collection command executed successfully",
+                    "Delete Operator request in progress",
                   );
-                  vscode.commands.executeCommand(VSCodeCommands.refresh);
-                })
-                .catch((e) => {
-                  session.operationPending = false;
+                  const poll = util.pollRun(10);
+                  const runDeleteOperatorCommand =
+                    ocSdkCommand.runDeleteOperatorCommand(outputChannel, logPath);
+                  Promise.all([poll, runDeleteOperatorCommand])
+                    .then(() => {
+                      session.operationPending = false;
+                      vscode.window.showInformationMessage(
+                        "Delete Operator command executed successfully",
+                      );
+                      vscode.commands.executeCommand(VSCodeCommands.refresh);
+                    })
+                    .catch((e) => {
+                      session.operationPending = false;
+                      vscode.window.showInformationMessage(
+                        `Failure executing Delete Operator command: RC ${e}`,
+                      );
+                    });
+                  break;
+                }
+                case VSCodeCommands.redeployCollection: {
                   vscode.window.showInformationMessage(
-                    `Failure executing Redeploy Collection command: RC ${e}`,
+                    "Redeploy Collection request in progress",
                   );
-                });
-              break;
-            }
-            case VSCodeCommands.redeployOperator: {
-              vscode.window.showInformationMessage(
-                "Redeploy Operator request in progress",
-              );
-              const poll = util.pollRun(40);
-              const runRedeployOperatorCommand =
-                ocSdkCommand.runRedeployOperatorCommand(outputChannel, logPath);
-              Promise.all([poll, runRedeployOperatorCommand])
-                .then(() => {
-                  session.operationPending = false;
+                  const poll = util.pollRun(30);
+                  const runRedeployCollectionCommand =
+                    ocSdkCommand.runRedeployCollectionCommand(
+                      outputChannel,
+                      logPath,
+                    );
+                  Promise.all([poll, runRedeployCollectionCommand])
+                    .then(() => {
+                      session.operationPending = false;
+                      vscode.window.showInformationMessage(
+                        "Redeploy Collection command executed successfully",
+                      );
+                      vscode.commands.executeCommand(VSCodeCommands.refresh);
+                    })
+                    .catch((e) => {
+                      session.operationPending = false;
+                      vscode.window.showInformationMessage(
+                        `Failure executing Redeploy Collection command: RC ${e}`,
+                      );
+                    });
+                  break;
+                }
+                case VSCodeCommands.redeployOperator: {
                   vscode.window.showInformationMessage(
-                    "Redeploy Operator command executed successfully",
+                    "Redeploy Operator request in progress",
                   );
-                  vscode.commands.executeCommand(VSCodeCommands.refresh);
-                })
-                .catch((e) => {
-                  session.operationPending = false;
-                  vscode.window.showInformationMessage(
-                    `Failure executing Redeploy Operator command: RC ${e}`,
-                  );
-                });
-              break;
+                  const poll = util.pollRun(40);
+                  const runRedeployOperatorCommand =
+                    ocSdkCommand.runRedeployOperatorCommand(outputChannel, logPath);
+                  Promise.all([poll, runRedeployOperatorCommand])
+                    .then(() => {
+                      session.operationPending = false;
+                      vscode.window.showInformationMessage(
+                        "Redeploy Operator command executed successfully",
+                      );
+                      vscode.commands.executeCommand(VSCodeCommands.refresh);
+                    })
+                    .catch((e) => {
+                      session.operationPending = false;
+                      vscode.window.showInformationMessage(
+                        `Failure executing Redeploy Operator command: RC ${e}`,
+                      );
+                    });
+                  break;
+                }
+              }
             }
           }
         }
-      }
+      }).catch((e) => {
+        vscode.window.showErrorMessage(
+          `Failure updating session: ${e}`,
+        );
+      });
     },
   );
 }
@@ -705,111 +760,127 @@ function executeSdkCommandWithUserInput(
   return vscode.commands.registerCommand(
     command,
     async (operatorItemArg: OperatorItem, logPath?: string) => {
-      let workspacePath: string | undefined = "";
-      if (operatorItemArg) {
-        workspacePath = operatorItemArg.workspacePath;
-      } else {
-        let pwd = util.getCurrentWorkspaceRootFolder();
-        if (pwd) {
-          workspacePath = await util.selectOperatorInWorkspace(pwd);
-          workspacePath = path.parse(workspacePath!).dir;
-        }
-      }
-      if (workspacePath) {
-        const k8s = new KubernetesObj();
-        const validNamespace = await k8s.validateNamespaceExists();
-        if (validNamespace) {
-          outputChannel?.show();
-          if (command === VSCodeCommands.createOperator) {
-            session.operationPending = true;
-            let playbookArgs = await util.requestOperatorInfo(workspacePath);
-            if (playbookArgs) {
-              let ocSdkCommand = new OcSdkCommand(workspacePath);
-              if (
-                playbookArgs.length === 1 &&
-                playbookArgs[0].includes("ocsdk-extra-vars")
-              ) {
-                vscode.window.showInformationMessage(
-                  "Create Operator request in progress using local variables file",
-                );
-              } else {
-                vscode.window.showInformationMessage(
-                  "Create Operator request in progress",
-                );
+      session.update().then(async (proceed) => {
+        if (proceed) {
+          let workspacePath: string | undefined = "";
+          if (operatorItemArg) {
+            workspacePath = operatorItemArg.workspacePath;
+          } else {
+            let pwd = util.getCurrentWorkspaceRootFolder();
+            if (pwd) {
+              workspacePath = await util.selectOperatorInWorkspace(pwd);
+              workspacePath = path.parse(workspacePath!).dir;
+            }
+          }
+          if (workspacePath) {
+            const k8s = new KubernetesObj();
+            const validNamespace = await k8s.validateNamespaceExists();
+            if (validNamespace) {
+              outputChannel?.show();
+              if (command === VSCodeCommands.createOperator) {
+                session.operationPending = true;
+                let playbookArgs = await util.requestOperatorInfo(workspacePath);
+                if (playbookArgs) {
+                  let ocSdkCommand = new OcSdkCommand(workspacePath);
+                  if (
+                    playbookArgs.length === 1 &&
+                    playbookArgs[0].includes("ocsdk-extra-vars")
+                  ) {
+                    vscode.window.showInformationMessage(
+                      "Create Operator request in progress using local variables file",
+                    );
+                  } else {
+                    vscode.window.showInformationMessage(
+                      "Create Operator request in progress",
+                    );
+                  }
+                  const poll = util.pollRun(40);
+                  const runCreateOperatorCommand =
+                    ocSdkCommand.runCreateOperatorCommand(
+                      playbookArgs,
+                      outputChannel,
+                      logPath,
+                    );
+                  Promise.all([poll, runCreateOperatorCommand])
+                    .then(() => {
+                      session.operationPending = false;
+                      vscode.window.showInformationMessage(
+                        "Create Operator command executed successfully",
+                      );
+                      vscode.commands.executeCommand(VSCodeCommands.refresh);
+                    })
+                    .catch((e) => {
+                      session.operationPending = false;
+                      vscode.window.showInformationMessage(
+                        `Failure executing Create Operator command: RC ${e}`,
+                      );
+                    });
+                }
               }
-              const poll = util.pollRun(40);
-              const runCreateOperatorCommand =
-                ocSdkCommand.runCreateOperatorCommand(
-                  playbookArgs,
-                  outputChannel,
-                  logPath,
-                );
-              Promise.all([poll, runCreateOperatorCommand])
-                .then(() => {
-                  session.operationPending = false;
-                  vscode.window.showInformationMessage(
-                    "Create Operator command executed successfully",
-                  );
-                  vscode.commands.executeCommand(VSCodeCommands.refresh);
-                })
-                .catch((e) => {
-                  session.operationPending = false;
-                  vscode.window.showInformationMessage(
-                    `Failure executing Create Operator command: RC ${e}`,
-                  );
-                });
             }
           }
         }
-      }
+      }).catch((e) => {
+        vscode.window.showErrorMessage(
+          `Failure updating session: ${e}`,
+        );
+      });
     },
   );
 }
 
-function deleteCustomResource(command: string) {
+function deleteCustomResource(command: string, session: Session) {
   return vscode.commands.registerCommand(
     command,
     async (customResourcArg: CustomResourcesItem) => {
-      if (customResourcArg) {
-        const k8s = new KubernetesObj();
-        const validNamespace = await k8s.validateNamespaceExists();
-        if (validNamespace) {
-          const name = customResourcArg.customResourceObj.metadata.name;
-          const apiVersion =
-            customResourcArg.customResourceObj.apiVersion.split("/")[1];
-          const kind = customResourcArg.customResourceObj.kind;
-          const poll = util.pollRun(15);
-          const deleteCustomResourceCmd = k8s.deleteCustomResource(
-            name,
-            apiVersion,
-            kind,
-          );
-          Promise.all([poll, deleteCustomResourceCmd])
-            .then((values) => {
-              const deleteSuccessful = values[1];
-              if (deleteSuccessful) {
-                vscode.window.showInformationMessage(
-                  `Successfully deleted ${kind} resource`,
-                );
-                vscode.commands.executeCommand(VSCodeCommands.resourceRefresh);
-              } else {
-                vscode.window.showErrorMessage(
-                  `Failed to delete ${kind} resource`,
-                );
-              }
-            })
-            .catch((e) => {
-              vscode.window.showErrorMessage(
-                `Failed to delete ${kind} resource: ${e}`,
+      session.update().then(async (proceed) => {
+        if (proceed) {
+          if (customResourcArg) {
+            const k8s = new KubernetesObj();
+            const validNamespace = await k8s.validateNamespaceExists();
+            if (validNamespace) {
+              const name = customResourcArg.customResourceObj.metadata.name;
+              const apiVersion =
+                customResourcArg.customResourceObj.apiVersion.split("/")[1];
+              const kind = customResourcArg.customResourceObj.kind;
+              const poll = util.pollRun(15);
+              const deleteCustomResourceCmd = k8s.deleteCustomResource(
+                name,
+                apiVersion,
+                kind,
               );
-            });
+              Promise.all([poll, deleteCustomResourceCmd])
+                .then((values) => {
+                  const deleteSuccessful = values[1];
+                  if (deleteSuccessful) {
+                    vscode.window.showInformationMessage(
+                      `Successfully deleted ${kind} resource`,
+                    );
+                    vscode.commands.executeCommand(VSCodeCommands.resourceRefresh);
+                  } else {
+                    vscode.window.showErrorMessage(
+                      `Failed to delete ${kind} resource`,
+                    );
+                  }
+                })
+                .catch((e) => {
+                  vscode.window.showErrorMessage(
+                    `Failed to delete ${kind} resource: ${e}`,
+                  );
+                });
+            }
+          } else {
+            vscode.window.showErrorMessage(
+              "Failed to delete custom resource. Please try again.",
+            );
+          }
         }
-      } else {
+      }).catch((e) => {
         vscode.window.showErrorMessage(
-          "Failed to delete custom resource. Please try again.",
+          `Failure updating session: ${e}`,
         );
-      }
-    },
+      });
+    }
   );
 }
 

--- a/src/test/runTest.ts
+++ b/src/test/runTest.ts
@@ -21,7 +21,7 @@ async function go() {
       "win32-x64-archive",
     );
   } else {
-    vscodeExecutablePath = await downloadAndUnzipVSCode("1.80.0");
+    vscodeExecutablePath = await downloadAndUnzipVSCode("1.82.2");
   }
   const [cliPath, ...args] =
     resolveCliArgsFromVSCodeExecutablePath(vscodeExecutablePath);

--- a/src/treeViews/providers/containerLogProvider.ts
+++ b/src/treeViews/providers/containerLogProvider.ts
@@ -19,13 +19,6 @@ export class ContainerLogProvider
     ContainerLogProvider.containerLogProviders.push(this);
   }
 
-  static async updateSession(): Promise<void> {
-    for (const provider of ContainerLogProvider.containerLogProviders) {
-      await provider.session.validateOcSDKInstallation();
-      await provider.session.validateOpenShiftAccess();
-    }
-  }
-
   async provideTextDocumentContent(uri: vscode.Uri): Promise<string> {
     if (this.session.loggedIntoOpenShift) {
       const k8s = new KubernetesObj();

--- a/src/treeViews/providers/customResourceDisplayProviders.ts
+++ b/src/treeViews/providers/customResourceDisplayProviders.ts
@@ -21,13 +21,6 @@ export class CustomResourceDisplayProvider
     CustomResourceDisplayProvider.customResourceDisplayProviders.push(this);
   }
 
-  static async updateSession(): Promise<void> {
-    for (const provider of CustomResourceDisplayProvider.customResourceDisplayProviders) {
-      await provider.session.validateOcSDKInstallation();
-      await provider.session.validateOpenShiftAccess();
-    }
-  }
-
   async provideTextDocumentContent(uri: vscode.Uri): Promise<string> {
     if (this.session.loggedIntoOpenShift) {
       const k8s = new KubernetesObj();

--- a/src/treeViews/providers/openshiftProvider.ts
+++ b/src/treeViews/providers/openshiftProvider.ts
@@ -30,13 +30,6 @@ export class OpenShiftTreeProvider
     OpenShiftTreeProvider.openshiftTreeProviders.push(this);
   }
 
-  static async updateSession(): Promise<void> {
-    for (const provider of OpenShiftTreeProvider.openshiftTreeProviders) {
-      await provider.session.validateOcSDKInstallation();
-      await provider.session.validateOpenShiftAccess();
-    }
-  }
-
   refresh(): void {
     this._onDidChangeTreeData.fire();
   }
@@ -48,46 +41,25 @@ export class OpenShiftTreeProvider
   async getChildren(element?: OpenShiftItem): Promise<OpenShiftItem[]> {
     const links: Array<OpenShiftItem> = [];
     const k8s = new KubernetesObj();
-    const updateOpenshiftTree = OpenShiftTreeProvider.updateSession();
-    const updateOperatorsTree = OperatorsTreeProvider.updateSession();
-    const refreshOperatorsTree = OperatorsTreeProvider.refreshAll();
-    const updateResourcesTree = ResourcesTreeProvider.updateSession();
-    const refreshResourcesTree = ResourcesTreeProvider.refreshAll();
-    const updateContainerLogsProvider = ContainerLogProvider.updateSession();
-    const updateCustomResourceDeployProvider =
-      CustomResourceDisplayProvider.updateSession();
-    const updateVerboseContainerLogProvider =
-      VerboseContainerLogProvider.updateSession();
-    return Promise.all([
-      updateOpenshiftTree,
-      updateOperatorsTree,
-      refreshOperatorsTree,
-      updateResourcesTree,
-      refreshResourcesTree,
-      updateContainerLogsProvider,
-      updateCustomResourceDeployProvider,
-      updateVerboseContainerLogProvider,
-    ]).then(() => {
-      if (this.session.loggedIntoOpenShift) {
-        links.push(
-          new OpenShiftItem(
-            "OpenShift Cluster",
-            k8s.openshiftServerURL,
-            new vscode.ThemeIcon("cloud"),
-            "openshift-cluster",
-          ),
-        );
-        links.push(
-          new OpenShiftItem(
-            "OpenShift Namespace",
-            k8s.namespace,
-            new vscode.ThemeIcon("account"),
-            "openshift-namespace",
-          ),
-        );
-      }
+    if (this.session.loggedIntoOpenShift) {
+      links.push(
+        new OpenShiftItem(
+          "OpenShift Cluster",
+          k8s.openshiftServerURL,
+          new vscode.ThemeIcon("cloud"),
+          "openshift-cluster",
+        ),
+      );
+      links.push(
+        new OpenShiftItem(
+          "OpenShift Namespace",
+          k8s.namespace,
+          new vscode.ThemeIcon("account"),
+          "openshift-namespace",
+        ),
+      );
+    }
 
-      return links;
-    });
+    return links;
   }
 }

--- a/src/treeViews/providers/operatorProvider.ts
+++ b/src/treeViews/providers/operatorProvider.ts
@@ -31,29 +31,6 @@ export class OperatorsTreeProvider
     OperatorsTreeProvider.operatorsTreeProviders.push(this);
   }
 
-  static async updateSession(): Promise<void> {
-    let ocSdkInstalled = true;
-    let loggedIntoOpenShift = true;
-    for (const provider of OperatorsTreeProvider.operatorsTreeProviders) {
-      ocSdkInstalled = await provider.session.validateOcSDKInstallation();
-      loggedIntoOpenShift = await provider.session.validateOpenShiftAccess();
-    }
-    if (!ocSdkInstalled) {
-      vscode.commands.executeCommand(
-        "setContext",
-        VSCodeCommands.sdkInstalled,
-        ocSdkInstalled,
-      );
-    }
-    if (!loggedIntoOpenShift) {
-      vscode.commands.executeCommand(
-        "setContext",
-        VSCodeCommands.loggedIn,
-        loggedIntoOpenShift,
-      );
-    }
-  }
-
   static refreshAll(): void {
     for (const provider of OperatorsTreeProvider.operatorsTreeProviders) {
       provider.refresh();
@@ -61,9 +38,7 @@ export class OperatorsTreeProvider
   }
 
   refresh(): void {
-    OperatorsTreeProvider.updateSession().then(() => {
-      this._onDidChangeTreeData.fire();
-    });
+    this._onDidChangeTreeData.fire();
   }
 
   getTreeItem(element: OperatorTreeItem): vscode.TreeItem {

--- a/src/treeViews/providers/resourceProvider.ts
+++ b/src/treeViews/providers/resourceProvider.ts
@@ -36,30 +36,6 @@ export class ResourcesTreeProvider
     // Store the instances on the static property
     ResourcesTreeProvider.resourceTreeProviders.push(this);
   }
-
-  static async updateSession(): Promise<void> {
-    let ocSdkInstalled = true;
-    let loggedIntoOpenShift = true;
-    for (const provider of ResourcesTreeProvider.resourceTreeProviders) {
-      ocSdkInstalled = await provider.session.validateOcSDKInstallation();
-      loggedIntoOpenShift = await provider.session.validateOpenShiftAccess();
-    }
-    if (!ocSdkInstalled) {
-      vscode.commands.executeCommand(
-        "setContext",
-        VSCodeCommands.sdkInstalled,
-        ocSdkInstalled,
-      );
-    }
-    if (!loggedIntoOpenShift) {
-      vscode.commands.executeCommand(
-        "setContext",
-        VSCodeCommands.loggedIn,
-        loggedIntoOpenShift,
-      );
-    }
-  }
-
   static refreshAll(): void {
     for (const provider of ResourcesTreeProvider.resourceTreeProviders) {
       provider.refresh();
@@ -67,9 +43,7 @@ export class ResourcesTreeProvider
   }
 
   refresh(): void {
-    ResourcesTreeProvider.updateSession().then(() => {
-      this._onDidChangeTreeData.fire();
-    });
+    this._onDidChangeTreeData.fire();
   }
 
   getTreeItem(element: ResourceItem): vscode.TreeItem {

--- a/src/treeViews/providers/verboseContainerLogProvider.ts
+++ b/src/treeViews/providers/verboseContainerLogProvider.ts
@@ -7,6 +7,7 @@ import * as vscode from "vscode";
 import * as util from "../../utilities/util";
 import { Session } from "../../utilities/session";
 import { KubernetesObj } from "../../kubernetes/kubernetes";
+import { VSCodeCommands } from "../../utilities/commandConstants";
 
 export class VerboseContainerLogProvider
   implements vscode.TextDocumentContentProvider
@@ -20,14 +21,7 @@ export class VerboseContainerLogProvider
     VerboseContainerLogProvider.verboseContainerLogProviders.push(this);
   }
 
-  static async updateSession(): Promise<void> {
-    for (const provider of VerboseContainerLogProvider.verboseContainerLogProviders) {
-      await provider.session.validateOcSDKInstallation();
-      await provider.session.validateOpenShiftAccess();
-    }
-  }
-
-  async provideTextDocumentContent(uri: vscode.Uri): Promise<string> {
+  async provideTextDocumentContent(uri: vscode.Uri): Promise<string | undefined> {
     if (this.session.loggedIntoOpenShift) {
       const k8s = new KubernetesObj();
       const uriObj = util.parseVerboseContainerLogUri(uri);
@@ -43,6 +37,5 @@ export class VerboseContainerLogProvider
       }
       return "";
     }
-    return "";
   }
 }


### PR DESCRIPTION
Prior to this fix, if a user was previously using the extension in VS Code and the OCP token expired, the user would then be flooded with tons of OCP errors. This fix now allows us to validate the session prior to executing any command, and immediately presents the user with the `Log In` prompt when this occurs.

- Move the `updateSession` functions from the individual providers to the new method under the `session` class.
- Execute `session.update()` prior to each command to perform the session validation prior to execution