### PR TITLE
Display z/OS Cloud Broker install status in About view

### DIFF
--- a/package.json
+++ b/package.json
@@ -216,6 +216,11 @@
         "when": "operator-collection-sdk.sdkInstalled && operator-collection-sdk.sdkOutdatedVersion"
       },
       {
+        "view": "operator-collection-sdk.operators",
+        "contents": "Install the z/OS Cloud Broker Operator in the current project in OpenShift",
+        "when": "operator-collection-sdk.loggedIn && !operator-collection-sdk.zosCloudBrokerInstalled"
+      },
+      {
         "view": "operator-collection-sdk.resources",
         "contents": "Install the IBM Operator Collection SDk to use this extension",
         "when": "!operator-collection-sdk.sdkInstalled"
@@ -255,6 +260,11 @@
         {
           "command": "operator-collection-sdk.refreshAll",
           "when": "view == operator-collection-sdk.openshiftClusterInfo",
+          "group": "navigation"
+        },
+        {
+          "command": "operator-collection-sdk.refreshAll",
+          "when": "view == operator-collection-sdk.about",
           "group": "navigation"
         }
       ],

--- a/package.json
+++ b/package.json
@@ -184,23 +184,29 @@
       "operator-collection-sdk": [
         {
           "id": "operator-collection-sdk.operators",
-          "name": "Operators"
+          "name": "Operators",
+          "initialSize": 3
         },
         {
           "id": "operator-collection-sdk.resources",
-          "name": "OpenShift Resources"
-        },
-        {
-          "id": "operator-collection-sdk.help",
-          "name": "Help And Additional Resources"
+          "name": "OpenShift Resources",
+          "initialSize": 3
         },
         {
           "id": "operator-collection-sdk.openshiftClusterInfo",
-          "name": "OpenShift Cluster Info"
+          "name": "OpenShift Cluster Info",
+          "initialSize": 1
         },
         {
           "id": "operator-collection-sdk.about",
-          "name": "About"
+          "name": "About",
+          "initialSize": 1
+        },
+        {
+          "id": "operator-collection-sdk.help",
+          "name": "Help And Additional Resources",
+          "visibility": "collapsed",
+          "initialSize": 1
         }
       ]
     },
@@ -217,13 +223,18 @@
       },
       {
         "view": "operator-collection-sdk.operators",
-        "contents": "Install the z/OS Cloud Broker Operator in the current project in OpenShift",
+        "contents": "Install the IBM z/OS Cloud Broker Operator in the current project in OpenShift to use this extension",
         "when": "operator-collection-sdk.loggedIn && !operator-collection-sdk.zosCloudBrokerInstalled"
       },
       {
         "view": "operator-collection-sdk.resources",
         "contents": "Install the IBM Operator Collection SDk to use this extension",
         "when": "!operator-collection-sdk.sdkInstalled"
+      },
+      {
+        "view": "operator-collection-sdk.resources",
+        "contents": "Install the IBM z/OS Cloud Broker Operator in the current project in OpenShift to use this extension",
+        "when": "operator-collection-sdk.loggedIn && !operator-collection-sdk.zosCloudBrokerInstalled"
       },
       {
         "view": "operator-collection-sdk.openshiftClusterInfo",
@@ -234,6 +245,11 @@
         "view": "operator-collection-sdk.operators",
         "contents": "Log in to an OpenShift Cluster to use this extension",
         "when": "!operator-collection-sdk.loggedIn && operator-collection-sdk.sdkInstalled"
+      },
+      {
+        "view": "operator-collection-sdk.about",
+        "contents": "IBM Operator Collection SDK and IBM z/OS Cloud Broker Operator not installed",
+        "when": "!operator-collection-sdk.sdkInstalled && operator-collection-sdk.loggedIn && !operator-collection-sdk.zosCloudBrokerInstalled"
       }
     ],
     "viewsContainers": {

--- a/package.json
+++ b/package.json
@@ -200,6 +200,7 @@
         {
           "id": "operator-collection-sdk.about",
           "name": "About",
+          "visibility": "collapsed",
           "initialSize": 1
         },
         {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -721,7 +721,9 @@ function executeSimpleSdkCommand(
                     ocSdkCommand.runRedeployCollectionCommand(
                       outputChannel,
                       logPath,
-                    );
+                    ).then(() => {
+                      session.operationPending = false;
+                    });
                   Promise.all([poll, runRedeployCollectionCommand])
                     .then(() => {
                       session.operationPending = false;
@@ -744,7 +746,9 @@ function executeSimpleSdkCommand(
                   );
                   const poll = util.pollRun(40);
                   const runRedeployOperatorCommand =
-                    ocSdkCommand.runRedeployOperatorCommand(outputChannel, logPath);
+                    ocSdkCommand.runRedeployOperatorCommand(outputChannel, logPath).then(() => {
+                      session.operationPending = false;
+                    });
                   Promise.all([poll, runRedeployOperatorCommand])
                     .then(() => {
                       session.operationPending = false;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -414,7 +414,7 @@ function logIn(
 ): vscode.Disposable {
   return vscode.commands.registerCommand(
     command,
-    async (params?: string[], logPath?: string) => {
+    async (openshiftItem: OpenShiftItem, params: string[], logPath?: string) => {
       let args: string[] | undefined = [];
       if (params === undefined || params?.length === 0) {
         args = await util.requestLogInInfo();
@@ -703,7 +703,7 @@ function executeSimpleSdkCommand(
                     })
                     .catch((e) => {
                       session.operationPending = false;
-                      vscode.window.showInformationMessage(
+                      vscode.window.showErrorMessage(
                         `Failure executing Delete Operator command: RC ${e}`,
                       );
                     });
@@ -729,7 +729,7 @@ function executeSimpleSdkCommand(
                     })
                     .catch((e) => {
                       session.operationPending = false;
-                      vscode.window.showInformationMessage(
+                      vscode.window.showErrorMessage(
                         `Failure executing Redeploy Collection command: RC ${e}`,
                       );
                     });
@@ -752,7 +752,7 @@ function executeSimpleSdkCommand(
                     })
                     .catch((e) => {
                       session.operationPending = false;
-                      vscode.window.showInformationMessage(
+                      vscode.window.showErrorMessage(
                         `Failure executing Redeploy Operator command: RC ${e}`,
                       );
                     });

--- a/src/shellCommands/ocSdkCommands.ts
+++ b/src/shellCommands/ocSdkCommands.ts
@@ -88,9 +88,11 @@ export class OcSdkCommand {
   }
 
   /**
-   * Executes the collection verify command to validate the collection is installed
+   * Executes the collection list command to validate the collection is installed
    * @param outputChannel - The VS Code output channel to display command output
    * @param logPath - Log path to store command output
+   * @param namespace - The Ansible Galaxy namespace
+   * @param collection - The Ansible Collection name (default: operator_collection_sdk)
    * @returns - A Promise container the return code of the command being executed
    */
   async runCollectionVerifyCommand(
@@ -99,20 +101,19 @@ export class OcSdkCommand {
     namespace?: string,
     collection: string = "operator_collection_sdk",
   ): Promise<string> {
-    const galaxyUrl = getAnsibleGalaxySettings(
-      AnsibleGalaxySettings.ansibleGalaxyURL,
-    ) as string;
     const galaxyNamespace =
       namespace ??
       (getAnsibleGalaxySettings(
         AnsibleGalaxySettings.ansibleGalaxyNamespace,
       ) as string);
+
+    // ansible-galaxy collection list | grep ibm.operator_collection_sdk
     const cmd: string = "ansible-galaxy";
     let args: Array<string> = [
       "collection",
-      "verify",
-      "-s",
-      galaxyUrl,
+      "list",
+      "|",
+      "grep",
       `${galaxyNamespace}.${collection}`,
     ];
     return this.run(cmd, args, outputChannel, logPath);

--- a/src/test/helper.ts
+++ b/src/test/helper.ts
@@ -1332,7 +1332,7 @@ export class TestKubernetesObj extends KubernetesContext {
 
   private async csvInstalledSuccessfully(): Promise<boolean> {
     const csv = await this.getBrokerCSV();
-    if (csv?.status?.phase && csv?.status?.phase === "Succeeded") {
+    if (csv?.status?.phase && csv?.status?.phase === CustomResourcePhases.succeeded) {
       return true;
     }
     return false;

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -98,6 +98,13 @@ describe("Extension Test Suite", async () => {
       }
 
       // Login to Openshift
+      const openShiftItem = new OpenShiftItem(
+        "OpenShift Cluster",
+        k8s.openshiftServerURL,
+        new vscode.ThemeIcon("cloud"),
+        "openshift-cluster",
+      );
+
       let args: Array<string> = [
         `--server="${testClusterInfo.ocpServerUrl}"`,
         `--token="${testClusterInfo.ocpToken}"`,
@@ -105,6 +112,7 @@ describe("Extension Test Suite", async () => {
       try {
         vscode.commands.executeCommand(
           VSCodeCommands.login,
+          openShiftItem,
           args,
           ocLoginLogPath,
         );

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -176,6 +176,7 @@ describe("Extension Test Suite", async () => {
     session = new Session(ocSdkCmd);
     await session.validateOcSDKInstallation();
     await session.validateOpenShiftAccess();
+    await session.validateZosCloudBrokerInstallation();
 
     try {
       vscode.commands.executeCommand(
@@ -1424,7 +1425,7 @@ async function installOperatorCollectionSDK(installSdkLogPath: string) {
   await util.sleep(15000);
   try {
     child_process.execSync(
-      "ansible-galaxy collection verify ibm.operator_collection_sdk",
+      "ansible-galaxy collection list | grep ibm.operator_collection_sdk",
     );
   } catch (e) {
     console.log("Printing Install OC SDK logs");

--- a/src/treeViews/aboutItems/aboutItem.ts
+++ b/src/treeViews/aboutItems/aboutItem.ts
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2023 IBM Inc. All rights reserved
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as vscode from "vscode";
+
+export class AboutItem extends vscode.TreeItem {
+  constructor(
+    public readonly name: string,
+    public readonly description: string,
+    public readonly icon: vscode.ThemeIcon | {
+        light: string | vscode.Uri;
+        dark: string | vscode.Uri;
+    },
+  ) {
+    super(name, vscode.TreeItemCollapsibleState.None);
+    this.contextValue = "about";
+    this.description = description;
+    this.iconPath = icon;
+  }
+}

--- a/src/treeViews/operatorItems/operatorItem.ts
+++ b/src/treeViews/operatorItems/operatorItem.ts
@@ -30,10 +30,10 @@ export class OperatorItem extends OperatorTreeItem {
  * @returns — A promise containing the WorkSpaceOperators object
  */
 export async function getOperatorItems(): Promise<OperatorItem[]> {
-  let operatorItems: Array<OperatorItem> = [];
-  for (const file of await vscode.workspace.findFiles(
-    "**/operator-config.*ml",
-  )) {
+  const operatorItems: Array<OperatorItem> = [];
+  const files = await vscode.workspace.findFiles("**/operator-config.*ml");
+  files.sort();
+  for (const file of files) {
     const operatorConigFilePath = file.fsPath;
     const workspacePath = path.parse(operatorConigFilePath).dir;
     let data = await vscode.workspace.openTextDocument(file);

--- a/src/treeViews/providers/aboutProvider.ts
+++ b/src/treeViews/providers/aboutProvider.ts
@@ -65,7 +65,7 @@ export class AboutTreeProvider
         aboutItems.push(
           new AboutItem(
             "IBM Operator Collection SDK",
-            ocSdkVersion,
+            ocSdkVersion!,
             brokerIcon
           )
         );

--- a/src/treeViews/providers/openshiftProvider.ts
+++ b/src/treeViews/providers/openshiftProvider.ts
@@ -7,11 +7,6 @@ import * as vscode from "vscode";
 import { OpenShiftItem } from "../openshiftItems/openshiftItem";
 import { KubernetesObj } from "../../kubernetes/kubernetes";
 import { Session } from "../../utilities/session";
-import { ResourcesTreeProvider } from "../../treeViews/providers/resourceProvider";
-import { OperatorsTreeProvider } from "../../treeViews/providers/operatorProvider";
-import { ContainerLogProvider } from "../../treeViews/providers/containerLogProvider";
-import { CustomResourceDisplayProvider } from "../../treeViews/providers/customResourceDisplayProviders";
-import { VerboseContainerLogProvider } from "../../treeViews/providers/verboseContainerLogProvider";
 
 type TreeItem = OpenShiftItem | undefined | void;
 

--- a/src/treeViews/providers/operatorProvider.ts
+++ b/src/treeViews/providers/operatorProvider.ts
@@ -12,7 +12,6 @@ import {
 import { getOperatorContainerItems } from "../operatorItems/operatorContainerItem";
 import { OperatorTreeItem } from "../operatorItems/operatorTreeItems";
 import { Session } from "../../utilities/session";
-import { VSCodeCommands } from "../../utilities/commandConstants";
 
 type TreeItem = OperatorTreeItem | undefined | void;
 
@@ -50,7 +49,8 @@ export class OperatorsTreeProvider
 
     if (this.session.loggedIntoOpenShift && 
       this.session.ocSdkInstalled &&
-      this.session.zosCloudBrokerInstalled) {
+      this.session.zosCloudBrokerInstalled &&
+      !this.session.ocSdkOutdated) {
       if (element) {
         // Get operator children items
         if (element instanceof OperatorItem) {

--- a/src/treeViews/providers/operatorProvider.ts
+++ b/src/treeViews/providers/operatorProvider.ts
@@ -48,7 +48,9 @@ export class OperatorsTreeProvider
   async getChildren(element?: OperatorTreeItem): Promise<OperatorTreeItem[]> {
     const operatorTreeItems: Array<OperatorTreeItem> = [];
 
-    if (this.session.loggedIntoOpenShift && this.session.ocSdkInstalled) {
+    if (this.session.loggedIntoOpenShift && 
+      this.session.ocSdkInstalled &&
+      this.session.zosCloudBrokerInstalled) {
       if (element) {
         // Get operator children items
         if (element instanceof OperatorItem) {

--- a/src/treeViews/providers/resourceProvider.ts
+++ b/src/treeViews/providers/resourceProvider.ts
@@ -53,7 +53,9 @@ export class ResourcesTreeProvider
   async getChildren(element?: ResourceTreeItem): Promise<ResourceTreeItem[]> {
     let resourceItems: Array<ResourceTreeItem> = [];
     const k8s = new KubernetesObj();
-    if (this.session.loggedIntoOpenShift && this.session.ocSdkInstalled) {
+    if (this.session.loggedIntoOpenShift && 
+      this.session.ocSdkInstalled && 
+      this.session.zosCloudBrokerInstalled) {
       if (element) {
         // Get operator children items
         if (element instanceof OperatorItem) {

--- a/src/utilities/commandConstants.ts
+++ b/src/utilities/commandConstants.ts
@@ -6,6 +6,7 @@
 export enum VSCodeCommands {
   sdkInstalled = "operator-collection-sdk.sdkInstalled",
   sdkOutdatedVersion = "operator-collection-sdk.sdkOutdatedVersion",
+  zosCloudBrokerInstalled = "operator-collection-sdk.zosCloudBrokerInstalled",
   sdkUpgradeVersion = "operator-collection-sdk.sdkUpgradeVersion",
   sdkUpgradeVersionSkip = "operator-collection-sdk.sdkUpgradeVersionSkip",
   loggedIn = "operator-collection-sdk.loggedIn",

--- a/src/utilities/util.ts
+++ b/src/utilities/util.ts
@@ -48,6 +48,7 @@ export const clusterServiceVersionApiVersion: string = "v1alpha1";
 export const zosEndpointApiVersion: string = "v2beta2";
 export const subOperatorConfigApiVersion: string = "v2beta2";
 export const operatorCollectionApiVersion: string = "v2beta2";
+export const zosCloudBrokerApiVersion: string = "v2beta1";
 
 export const logScheme: string = "containerLogs";
 export const verboseLogScheme: string = "verboseContainerLogs";


### PR DESCRIPTION
closes #23

- Display z/OS Cloud Broker install status and version in the About view
- Require that z/OS Cloud Broker is installed in the current project before using the extension
- Updated `runCollectionVerifyCommand()` to use the `list` command to allow for the installation of collection not published to Ansible Galaxy
- Fixed test failures that were due to previous tests not setting the `operatorPending` flag to `false` because polling was still active
- Added ability to install `preReleased` collection (i.e 1.1.0-beta.1)
- Operator Collection SDK version update fixes