### PR TITLE
Added ability to refresh pod logs 

### DIFF
--- a/package.json
+++ b/package.json
@@ -224,7 +224,7 @@
       },
       {
         "view": "operator-collection-sdk.operators",
-        "contents": "Install the IBM z/OS Cloud Broker Operator in the current project in OpenShift to use this extension",
+        "contents": "Install the IBM z/OS Cloud Broker Operator in the current project in OpenShift, and create a ZosCloudBroker instance to use this extension",
         "when": "operator-collection-sdk.loggedIn && !operator-collection-sdk.zosCloudBrokerInstalled"
       },
       {
@@ -234,7 +234,7 @@
       },
       {
         "view": "operator-collection-sdk.resources",
-        "contents": "Install the IBM z/OS Cloud Broker Operator in the current project in OpenShift to use this extension",
+        "contents": "Install the IBM z/OS Cloud Broker Operator in the current project in OpenShift, and create a ZosCloudBroker instance to use this extension",
         "when": "operator-collection-sdk.loggedIn && !operator-collection-sdk.zosCloudBrokerInstalled"
       },
       {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   },
   "icon": "resources/icons/broker-logo.png",
   "description": "IBM Operator Collection SDK VS Code extension for Operator Collection development",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/IBM/operator-collection-sdk-vscode-extension"

--- a/package.json
+++ b/package.json
@@ -351,6 +351,60 @@
           "when": "view == operator-collection-sdk.openshiftClusterInfo && viewItem == openshift-namespace",
           "group": "inline"
         }
+      ],
+      "commandPalette": [
+        {
+          "command": "operator-collection-sdk.viewLogs",
+          "when": "false"
+        },
+        {
+          "command": "operator-collection-sdk.viewVerboseLogs",
+          "when": "false"
+        },
+        {
+          "command": "operator-collection-sdk.openEditLink",
+          "when": "false"
+        },
+        {
+          "command": "operator-collection-sdk.viewResource",
+          "when": "false"
+        },
+        {
+          "command": "operator-collection-sdk.openAddLink",
+          "when": "false"
+        },
+        {
+          "command": "operator-collection-sdk.deleteCustomResource",
+          "when": "false"
+        },
+        {
+          "command": "operator-collection-sdk.login",
+          "when": "false"
+        },
+        {
+          "command": "operator-collection-sdk.logout",
+          "when": "false"
+        },
+        {
+          "command": "operator-collection-sdk.updateProject",
+          "when": "false"
+        },
+        {
+          "command": "operator-collection-sdk.refresh",
+          "when": "false"
+        },
+        {
+          "command": "operator-collection-sdk.resourceRefresh",
+          "when": "false"
+        },
+        {
+          "command": "operator-collection-sdk.refreshAll",
+          "when": "false"
+        },
+        {
+          "command": "operator-collection-sdk.refreshOpenShiftInfo",
+          "when": "false"
+        }
       ]
     },
     "yamlValidation": [

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -631,32 +631,26 @@ function executeContainerViewLogCommand(command: string, session: Session): vsco
                         workspacePath,
                       );
                     let crInstance: string | undefined = "";
-                    if (kind !== undefined) {
-                      if (apiVersion) {
-                        crInstance = await util.selectCustomResourceInstance(
-                          workspacePath,
-                          k8s,
+                    if (kind !== undefined && apiVersion !== undefined) {
+                      crInstance = await util.selectCustomResourceInstance(
+                        workspacePath,
+                        k8s,
+                        apiVersion,
+                        kind,
+                      );
+                      if (crInstance !== undefined) {
+                        const logUri = util.buildVerboseContainerLogUri(
+                          containerItemArgs.podObj.metadata?.name!,
+                          containerItemArgs.containerStatus.name,
                           apiVersion,
-                          kind!,
+                          kind,
+                          crInstance,
                         );
-                        if (kind && crInstance) {
-                          const logUri = util.buildVerboseContainerLogUri(
-                            containerItemArgs.podObj.metadata?.name!,
-                            containerItemArgs.containerStatus.name,
-                            apiVersion,
-                            kind,
-                            crInstance,
-                          );
-                          const doc = await vscode.workspace.openTextDocument(logUri);
-                          await vscode.window.showTextDocument(doc, {
-                            preview: false,
-                          });
-                          vscode.commands.executeCommand(VSCodeCommands.refreshVerboseContainerLog, logUri);
-                        }
-                      } else {
-                        vscode.window.showErrorMessage(
-                          "Unable to download log due to undefined version in operator-config",
-                        );
+                        const doc = await vscode.workspace.openTextDocument(logUri);
+                        await vscode.window.showTextDocument(doc, {
+                          preview: false,
+                        });
+                        vscode.commands.executeCommand(VSCodeCommands.refreshVerboseContainerLog, logUri);
                       }
                     }
                   }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -251,6 +251,32 @@ export async function activate(context: vscode.ExtensionContext) {
     }),
   );
   context.subscriptions.push(
+    vscode.commands.registerCommand(VSCodeCommands.refreshContainerLog, (uri: vscode.Uri) => {
+      session.update().then((proceed) => {
+        if (proceed) {
+          containerLogProvider.refresh(uri);
+        }
+      }).catch((e) => {
+        vscode.window.showErrorMessage(
+          `Failure updating session: ${e}`,
+        );
+      });
+    }),
+  );
+  context.subscriptions.push(
+    vscode.commands.registerCommand(VSCodeCommands.refreshVerboseContainerLog, (uri: vscode.Uri) => {
+      session.update().then((proceed) => {
+        if (proceed) {
+          verboseContainerLogProvider.refresh(uri);
+        }
+      }).catch((e) => {
+        vscode.window.showErrorMessage(
+          `Failure updating session: ${e}`,
+        );
+      });
+    }),
+  );
+  context.subscriptions.push(
     vscode.commands.registerCommand(
       VSCodeCommands.sdkUpgradeVersionSkip,
       () => {
@@ -594,6 +620,7 @@ function executeContainerViewLogCommand(command: string, session: Session): vsco
                     );
                     const doc = await vscode.workspace.openTextDocument(logUri);
                     await vscode.window.showTextDocument(doc, { preview: false });
+                    vscode.commands.executeCommand(VSCodeCommands.refreshContainerLog, logUri);
                     break;
                   }
                   case VSCodeCommands.viewVerboseLogs: {
@@ -623,6 +650,7 @@ function executeContainerViewLogCommand(command: string, session: Session): vsco
                         await vscode.window.showTextDocument(doc, {
                           preview: false,
                         });
+                        vscode.commands.executeCommand(VSCodeCommands.refreshVerboseContainerLog, logUri);
                       }
                     } else {
                       vscode.window.showErrorMessage(

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -631,31 +631,33 @@ function executeContainerViewLogCommand(command: string, session: Session): vsco
                         workspacePath,
                       );
                     let crInstance: string | undefined = "";
-                    if (apiVersion) {
-                      crInstance = await util.selectCustomResourceInstance(
-                        workspacePath,
-                        k8s,
-                        apiVersion,
-                        kind!,
-                      );
-                      if (kind && crInstance) {
-                        const logUri = util.buildVerboseContainerLogUri(
-                          containerItemArgs.podObj.metadata?.name!,
-                          containerItemArgs.containerStatus.name,
+                    if (kind !== undefined) {
+                      if (apiVersion) {
+                        crInstance = await util.selectCustomResourceInstance(
+                          workspacePath,
+                          k8s,
                           apiVersion,
-                          kind,
-                          crInstance,
+                          kind!,
                         );
-                        const doc = await vscode.workspace.openTextDocument(logUri);
-                        await vscode.window.showTextDocument(doc, {
-                          preview: false,
-                        });
-                        vscode.commands.executeCommand(VSCodeCommands.refreshVerboseContainerLog, logUri);
+                        if (kind && crInstance) {
+                          const logUri = util.buildVerboseContainerLogUri(
+                            containerItemArgs.podObj.metadata?.name!,
+                            containerItemArgs.containerStatus.name,
+                            apiVersion,
+                            kind,
+                            crInstance,
+                          );
+                          const doc = await vscode.workspace.openTextDocument(logUri);
+                          await vscode.window.showTextDocument(doc, {
+                            preview: false,
+                          });
+                          vscode.commands.executeCommand(VSCodeCommands.refreshVerboseContainerLog, logUri);
+                        }
+                      } else {
+                        vscode.window.showErrorMessage(
+                          "Unable to download log due to undefined version in operator-config",
+                        );
                       }
-                    } else {
-                      vscode.window.showErrorMessage(
-                        "Unable to download log due to undefined version in operator-config",
-                      );
                     }
                   }
                 }

--- a/src/kubernetes/kubernetes.ts
+++ b/src/kubernetes/kubernetes.ts
@@ -182,6 +182,11 @@ export class KubernetesObj extends KubernetesContext {
         return res.body;
       })
       .catch((e) => {
+        const errorMessage = e.body?.message as String;
+        if (errorMessage.includes("PodInitializing")) {
+          vscode.window.showErrorMessage("Unable to retrieve logs for this container while the Pod is initializing. Please try again after Pod initialization completes.");
+          return undefined;
+        } 
         const msg = `Failure retrieving Pod logs. ${JSON.stringify(e)}`;
         console.error(msg);
         vscode.window.showErrorMessage(msg);

--- a/src/treeViews/providers/aboutProvider.ts
+++ b/src/treeViews/providers/aboutProvider.ts
@@ -8,7 +8,6 @@ import { Session } from "../../utilities/session";
 import { AboutItem } from "../aboutItems/aboutItem";
 import { getBrokerIconPath } from "../../utilities/util";
 import { KubernetesObj } from "../../kubernetes/kubernetes";
-import { VSCodeCommands } from "../../utilities/commandConstants";
 
 type TreeItem = vscode.TreeItem | undefined | void;
 

--- a/src/treeViews/providers/containerLogProvider.ts
+++ b/src/treeViews/providers/containerLogProvider.ts
@@ -11,12 +11,15 @@ import { KubernetesObj } from "../../kubernetes/kubernetes";
 export class ContainerLogProvider
   implements vscode.TextDocumentContentProvider
 {
-  // Static property to store the instances
-  private static containerLogProviders: ContainerLogProvider[] = [];
 
-  constructor(private readonly session: Session) {
-    // Store the instances on the static property
-    ContainerLogProvider.containerLogProviders.push(this);
+
+  constructor(private readonly session: Session) {}
+
+  onDidChangeEmitter = new vscode.EventEmitter<vscode.Uri>();
+  onDidChange = this.onDidChangeEmitter.event;
+
+  refresh(uri: vscode.Uri): void {
+    this.onDidChangeEmitter.fire(uri);
   }
 
   async provideTextDocumentContent(uri: vscode.Uri): Promise<string> {

--- a/src/treeViews/providers/verboseContainerLogProvider.ts
+++ b/src/treeViews/providers/verboseContainerLogProvider.ts
@@ -12,13 +12,14 @@ import { VSCodeCommands } from "../../utilities/commandConstants";
 export class VerboseContainerLogProvider
   implements vscode.TextDocumentContentProvider
 {
-  // Static property to store the instances
-  private static verboseContainerLogProviders: VerboseContainerLogProvider[] =
-    [];
 
-  constructor(private readonly session: Session) {
-    // Store the instances on the static property
-    VerboseContainerLogProvider.verboseContainerLogProviders.push(this);
+  constructor(private readonly session: Session) {}
+
+  onDidChangeEmitter = new vscode.EventEmitter<vscode.Uri>();
+  onDidChange = this.onDidChangeEmitter.event;
+
+  refresh(uri: vscode.Uri): void {
+    this.onDidChangeEmitter.fire(uri);
   }
 
   async provideTextDocumentContent(uri: vscode.Uri): Promise<string | undefined> {

--- a/src/utilities/commandConstants.ts
+++ b/src/utilities/commandConstants.ts
@@ -29,6 +29,8 @@ export enum VSCodeCommands {
   resourceRefresh = "operator-collection-sdk.resourceRefresh",
   refreshAll = "operator-collection-sdk.refreshAll",
   refreshOpenShiftInfo = "operator-collection-sdk.refreshOpenShiftInfo",
+  refreshContainerLog = "operator-collection-sdk.refreshContainerLog",
+  refreshVerboseContainerLog = "operator-collection-sdk.refreshVerboseContainerLog",
 }
 
 export enum VSCodeViewIds {


### PR DESCRIPTION
- Added ability to refresh pod logs
- Removed context commands from command palette (Those commands can't run standalone and require context from the tree view)
- Added fix for failure when escaping Kind selection when opening verbose container logs
- Display error when downloading logs before container is initialized