### PR TITLE
Updated login function in kubernetes context

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "operator-collection-sdk",
-  "version": "0.4.0",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "operator-collection-sdk",
-      "version": "0.4.0",
+      "version": "1.0.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@kubernetes/client-node": "^0.18.1",

--- a/src/kubernetes/kubernetesContext.ts
+++ b/src/kubernetes/kubernetesContext.ts
@@ -4,6 +4,7 @@ import * as k8s from "@kubernetes/client-node";
 import * as fs from "fs";
 import { VSCodeCommands } from "../utilities/commandConstants";
 import { OcCommand } from "../shellCommands/ocCommand";
+import * as util from "../utilities/util";
 
 export class KubernetesContext {
   public coreV1Api: k8s.CoreV1Api | undefined = undefined;
@@ -48,7 +49,7 @@ export class KubernetesContext {
         }
       });
     } else {
-      // validate kube config by trying to make APi Client
+      // validate kube config by trying to make Api Clients
       try {
         this.openshiftServerURL = kc.getCurrentCluster()?.server;
         this.coreV1Api = kc.makeApiClient(k8s.CoreV1Api);
@@ -67,7 +68,7 @@ export class KubernetesContext {
    */
   public async attemptOCLogin(ocCmd: OcCommand): Promise<Boolean> {
     return new Promise(async (resolve, reject) => {
-      const args = await this.requestLogInInfo();
+      const args = await util.requestLogInInfo();
       if (args) {
         try {
           const response = await ocCmd.runOcLoginCommand(args);
@@ -83,41 +84,5 @@ export class KubernetesContext {
         reject(false);
       }
     });
-  }
-
-  /**
-   * A copy of the requestLogInInfo from utilities. Copied to avoid circular dependency issue.
-   * @returns - A Promise containing an array of `oc login` arguments or undefined.
-   */
-  private async requestLogInInfo(): Promise<string[] | undefined> {
-    let args: Array<string> = [];
-
-    const serverURL = await vscode.window.showInputBox({
-      prompt: "Enter your OpenShift Server URL",
-      ignoreFocusOut: true,
-    });
-
-    if (serverURL === undefined) {
-      return undefined;
-    } else if (serverURL === "") {
-      vscode.window.showErrorMessage("OpenShift server URL is required to log in");
-      return undefined;
-    }
-
-    args.push(`--server="${serverURL}"`);
-    const token = await vscode.window.showInputBox({
-      prompt: "Enter your OpenShift token",
-      password: true,
-      ignoreFocusOut: true,
-    });
-
-    if (token === undefined) {
-      return undefined;
-    } else if (token === "") {
-      vscode.window.showErrorMessage("OpenShift token is required to log in");
-      return undefined;
-    }
-    args.push(`--token="${token}"`);
-    return args;
   }
 }

--- a/src/kubernetes/kubernetesContext.ts
+++ b/src/kubernetes/kubernetesContext.ts
@@ -65,7 +65,7 @@ export class KubernetesContext {
    * @param ocCmd - The oc command to be executed
    * @returns - A Promise containing a boolean signaling the success of the executed command
    */
-  public async attemptOCLogin(ocCmd: OcCommand): Promise<Boolean> {
+  private async attemptOCLogin(ocCmd: OcCommand): Promise<Boolean> {
     return new Promise(async (resolve, reject) => {
       const args = await this.requestLogInInfo();
       if (args) {
@@ -90,7 +90,7 @@ export class KubernetesContext {
    * Prompts the user for the necessary info to log in to an OpenShift cluster
    * @returns - A Promise containing the list of parameters to pass to the command
    */
-  public async requestLogInInfo(): Promise<string[] | undefined> {
+  private async requestLogInInfo(): Promise<string[] | undefined> {
     let args: Array<string> = [];
 
     const inputArgs = await vscode.window.showInputBox({

--- a/src/kubernetes/kubernetesContext.ts
+++ b/src/kubernetes/kubernetesContext.ts
@@ -4,7 +4,6 @@ import * as k8s from "@kubernetes/client-node";
 import * as fs from "fs";
 import { VSCodeCommands } from "../utilities/commandConstants";
 import { OcCommand } from "../shellCommands/ocCommand";
-import * as util from "../utilities/util";
 
 export class KubernetesContext {
   public coreV1Api: k8s.CoreV1Api | undefined = undefined;

--- a/src/utilities/util.ts
+++ b/src/utilities/util.ts
@@ -472,7 +472,6 @@ export async function requestLogInInfo(): Promise<string[] | undefined> {
 
     return args;
   } else {
-    vscode.window.showErrorMessage("Failed to log in because no arguments were supplied.");
     return undefined;
   }
 }


### PR DESCRIPTION
~Updated login function in `kubernetesContext.ts` to use `util.requestLoginInfo` because circular dependency has vanished.~

- Makes it so the login (when kube config is invalid) only takes on argument (the whole `oc login` command).
- Circular dependency still exists, so the `requestLoginInfo` function is duplicated from util