### PR TITLE
Added support of oc-lint yaml config

### DIFF
--- a/LINTER.md
+++ b/LINTER.md
@@ -1,0 +1,42 @@
+# IBM Operator Collection SDK for VS Code integrated linter configuration
+
+The IBM Operator Collection SDK for VS Code has a built-in linter meant to validate your operator-config,
+By default the following rules are applied:
+
+- missing-galaxy
+- match-domain
+- match-name
+- match-version
+- ansible-config
+- playbook-path
+- hosts-all 
+- missing-playbook
+- finalizer-path
+- missing-finalizer
+
+You can customize the linter rules and files to ignore to suit your needs. You can ignore certain rules, enable rules, and ignore files from linting.
+
+The IBM Operator Collection SDK for VS Code Operator Collection Linter loads configuration from a file in the directory where the operator-config is located,
+Specify this configuration in `.oc-lint` a yaml file that contains the following format:
+
+```
+---
+# .oc-lint
+
+exclude_paths:
+    - '**'
+
+use_default_rules: true
+
+skip_list:
+    - match-domain
+    
+enable_list:
+    - hosts-all
+```
+
+Where:
+- `exlude_paths` defines a glob pattern to ignore when matching against the files the linter will process.
+- `use_default_rules` Enables all the linting rules to be applied.
+- `skip_list` Lists all the rules you want disabled.
+- `enable_list` Lists all the rules you want to explicitly enable.

--- a/LINTER.md
+++ b/LINTER.md
@@ -3,16 +3,26 @@
 The IBM Operator Collection SDK for VS Code has a built-in linter meant to validate your operator-config,
 By default the following rules are applied:
 
-- missing-galaxy
-- match-domain
-- match-name
-- match-version
-- ansible-config
-- playbook-path
-- hosts-all 
-- missing-playbook
-- finalizer-path
-- missing-finalizer
+- `missing-galaxy`
+  - Missing `galaxy.yaml` file errors.
+- `match-domain`
+  - `galaxy.yml` file `domain` mismatch
+- `match-name`
+  - `galaxy.yml` file `name` mismatch
+- `match-version`
+  - `galaxy.yml` file `version` mismatch
+- `ansible-config`
+  - Build includes `ansible.cfg` error
+- `playbook-path`
+  - Playbook relative path validation error
+- `hosts-all`
+  - Playbook hosts validation
+- `missing-playbook`
+  - Validate Playbook existence
+- `finalizer-path`
+  - Finalizer relative path validation error
+- `missing-finalizer`
+  - Validate Finalizer existence
 
 You can customize the linter rules and files to ignore to suit your needs. You can ignore certain rules, enable rules, and ignore files from linting.
 
@@ -23,14 +33,18 @@ Specify this configuration in `.oc-lint` a yaml file that contains the following
 ---
 # .oc-lint
 
+# List of files for the linter to ignore.
 exclude_paths:
     - '**'
 
+# Use all the default linter rules
 use_default_rules: true
 
+# List of rules to skip linting.
 skip_list:
     - match-domain
-    
+
+# List of additional rules to enable.
 enable_list:
     - hosts-all
 ```

--- a/package.json
+++ b/package.json
@@ -425,6 +425,10 @@
       {
         "fileMatch": "operator-config.yml",
         "url": "./resources/schema/operator-config.schema.json"
+      },
+      {
+        "fileMatch": ".oc-lint",
+        "url": "./resources/schema/oc-lint.schema.json"
       }
     ]
   },

--- a/resources/schema/oc-lint.schema.json
+++ b/resources/schema/oc-lint.schema.json
@@ -1,0 +1,59 @@
+{
+    "$schema": "http://json-schema.org/draft-06/schema#",
+    "$ref": "#/definitions/OcLinterConfig",
+    "definitions": {
+        "OcLinterConfig": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "exclude_paths": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "use_default_rules": {
+                    "type": "boolean"
+                },
+                "skip_list": {
+                    "type": "array",
+                    "items": {
+                        "type": "string",
+                        "enum": [
+                            "missing-galaxy",
+                            "match-domain",
+                            "match-name",
+                            "match-version",
+                            "ansible-config",
+                            "playbook-path",
+                            "hosts-all",
+                            "missing-playbook",
+                            "finalizer-path",
+                            "missing-finalizer"
+                        ]
+                    }
+                },
+                "enable_list": {
+                    "type": "array",
+                    "items": {
+                        "type": "string",
+                        "enum": [
+                            "missing-galaxy",
+                            "match-domain",
+                            "match-name",
+                            "match-version",
+                            "ansible-config",
+                            "playbook-path",
+                            "hosts-all",
+                            "missing-playbook",
+                            "finalizer-path",
+                            "missing-finalizer"
+                        ]
+                    }
+                }
+            },
+            "required": [],
+            "title": "OcLinterConfig"
+        }
+    }
+}

--- a/resources/schema/oc-lint.schema.json
+++ b/resources/schema/oc-lint.schema.json
@@ -2,58 +2,74 @@
     "$schema": "http://json-schema.org/draft-06/schema#",
     "$ref": "#/definitions/OcLinterConfig",
     "definitions": {
+        "Rule": {
+            "type": "string",
+            "oneOf": [
+              {"const":"missing-galaxy",
+              "markdownDescription": "#### Description\r\nMissing `galaxy.yaml` file errors."
+              },
+              {"const":"match-domain",
+              "markdownDescription": "#### Description\r\n`galaxy.yml` file domain mismatch"
+              },
+              {"const":"match-name",
+              "markdownDescription": "#### Description\r\n`galaxy.yml` file name mismatch"
+              },
+              {"const":"match-version",
+              "markdownDescription": "#### Description\r\n`galaxy.yml` file version mismatch"
+              },
+              {"const":"ansible-config",
+              "markdownDescription": "#### Description\r\nBuild includes `ansible.cfg` error"
+              },
+              {"const":"playbook-path",
+              "markdownDescription": "#### Description\r\nPlaybook relative path validation error"
+              },
+              {"const":"hosts-all",
+              "markdownDescription": "#### Description\r\nPlaybook hosts validation"
+              },
+              {"const":"finalizer-path",
+              "markdownDescription": "#### Description\r\nFinalizer relative path validation error"
+              },
+              {"const":"missing-finalizer",
+              "markdownDescription": "#### Description\r\nValidate Finalizer existence"
+              },
+              {"const":"missing-playbook",
+              "markdownDescription": "#### Description\r\nValidate Playbook existence"
+              }
+            ]
+        },
         "OcLinterConfig": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
                 "exclude_paths": {
+                    "markdownDescription": "#### Description\r\nList of files for the linter to ignore.",
                     "type": "array",
                     "items": {
                         "type": "string"
                     }
                 },
                 "use_default_rules": {
+                    "markdownDescription": "#### Description\r\nUse all the default linter rules.",
                     "type": "boolean"
                 },
                 "skip_list": {
+                    "markdownDescription": "#### Description\r\nList of rules to skip linting.",
                     "type": "array",
                     "items": {
                         "type": "string",
-                        "enum": [
-                            "missing-galaxy",
-                            "match-domain",
-                            "match-name",
-                            "match-version",
-                            "ansible-config",
-                            "playbook-path",
-                            "hosts-all",
-                            "missing-playbook",
-                            "finalizer-path",
-                            "missing-finalizer"
-                        ]
+                        "$ref": "#/definitions/Rule"
                     }
                 },
                 "enable_list": {
+                    "markdownDescription": "#### Description\r\nList of additional rules to enable.",
                     "type": "array",
                     "items": {
                         "type": "string",
-                        "enum": [
-                            "missing-galaxy",
-                            "match-domain",
-                            "match-name",
-                            "match-version",
-                            "ansible-config",
-                            "playbook-path",
-                            "hosts-all",
-                            "missing-playbook",
-                            "finalizer-path",
-                            "missing-finalizer"
-                        ]
+                        "$ref": "#/definitions/Rule"
                     }
                 }
             },
-            "required": [],
-            "title": "OcLinterConfig"
+            "required": []
         }
     }
 }

--- a/resources/schema/operator-config.schema.json
+++ b/resources/schema/operator-config.schema.json
@@ -100,13 +100,13 @@
 				"domain": {
 					"type": "string",
 					"maxLength": 253,
-					"pattern": "^(?![0-9]+$)(?!.*-$)(?!-)[a-zA-Z0-9-]{1,253}$",
+					"pattern": "^(?![0-9]+$)(?!.*-$)(?!-)[a-zA-Z0-9-]{1,253}$|^{{\\s*.+\\s*}}$",
 					"markdownDescription": "#### Description\r\nA unique value that will be used to construct the Kubernetes API group for the `resources` defined in this `OperatorCollection`.\r\nThis value MUST conform to the Kubernetes DNS Subdomain naming scheme as defined in RFC 1123.\r\nThis value SHOULD be the same as the `namespace` value specified in an Ansible Collection's `galaxy.yml` file. In scenarios where forks/clones of an official Ansible Collection are desired, the `domain` value MAY be set to another unique, conforming"
 				},
 				"name": {
 					"type": "string",
 					"maxLength": 253,
-					"pattern": "^(?![0-9]+$)(?!.*-$)(?!-)[a-zA-Z0-9-]{1,253}$",
+					"pattern": "^(?![0-9]+$)(?!.*-$)(?!-)[a-zA-Z0-9-]{1,253}$|^{{\\s*.+\\s*}}$",
 					"markdownDescription": "#### Description\r\nA unique value that will be prepended to the `domain` value to construct a full Kubernetes API Group for the `resources` defined in this `OperatorCollection`.\r\nThis value MUST conform to the Kubernetes DNS Subdomain naming scheme as defined in RFC 1123.\r\nThis value SHOULD be the same as the `name` value specified in an Ansible Collection's `galaxy.yml` file. In scenarios where forks/clones of an official Ansible Collection are desired, the `name` value MAY be set to another unique, conforming, value."
 				},
 				"provider": {
@@ -124,7 +124,7 @@
 				},
 				"version": {
 					"type": "string",
-					"pattern": "^(0|[1-9][0-9]*)[.](0|[1-9][0-9]*)[.](0|[1-9][0-9]*)(?:-((?:0|[1-9][0-9]*|[0-9]*[a-zA-Z-][0-9a-zA-Z-]*)(?:[.](?:0|[1-9][0-9]*|[0-9]*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:[+]([0-9a-zA-Z-]+(?:[.][0-9a-zA-Z-]+)*))?$",
+					"pattern": "^(0|[1-9][0-9]*)[.](0|[1-9][0-9]*)[.](0|[1-9][0-9]*)(?:-((?:0|[1-9][0-9]*|[0-9]*[a-zA-Z-][0-9a-zA-Z-]*)(?:[.](?:0|[1-9][0-9]*|[0-9]*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:[+]([0-9a-zA-Z-]+(?:[.][0-9a-zA-Z-]+)*))?$|^{{\\s*.+\\s*}}$",
 					"markdownDescription": "#### Description\r\nA semantic versioning compliant version number.\r\nThis value SHOULD be the same as the `version` value specified in an Ansible Collection's `galaxy.yml` file."
 				},
 				"icon": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -33,6 +33,7 @@ import { OperatorConfig } from "./linter/models";
 import { AnsibleGalaxyYmlSchema } from "./linter/galaxy";
 import { getLinterSettings, LinterSettings } from "./utilities/util";
 import * as yaml from "js-yaml";
+import { Minimatch } from "minimatch";
 import { AboutTreeProvider } from "./treeViews/providers/aboutProvider";
 
 export async function activate(context: vscode.ExtensionContext) {
@@ -705,8 +706,75 @@ function deleteCustomResource(command: string, session: Session) {
   });
 }
 
+const ocLinterRules = ["missing-galaxy", "match-domain", "match-name", "match-version", "ansible-config", "playbook-path", "hosts-all", "missing-playbook", "finalizer-path", "missing-finalizer"];
+var linterConfigured: ocLintConfig;
+var filteredRules: string[];
+interface ocLintConfig {
+  //ignores
+  exclude_paths?: string[];
+  //rules
+  skip_list?: string[];
+  enable_list?: string[];
+  use_default_rules?: boolean;
+}
+
+function configureLinter(oc_lint_path: string) {
+  linterConfigured = {
+    exclude_paths: [],
+    skip_list: [],
+    enable_list: [],
+    use_default_rules: true,
+  };
+
+  try {
+    let ocLintFile = fs.readFileSync(oc_lint_path, "utf8");
+    let ocConfig = yaml.load(ocLintFile) as ocLintConfig;
+
+    //Process useDefaultRules
+    if (ocConfig.use_default_rules) {
+      filteredRules = ocLinterRules;
+    } else {
+      filteredRules = [];
+    }
+    //Process enable_list
+    if (ocConfig.enable_list !== undefined) {
+      let includeRules = ocConfig.enable_list.filter(rule => ocLinterRules.includes(rule));
+      includeRules.forEach(rule => {
+        !filteredRules.includes(rule) && filteredRules.push(rule);
+      });
+    }
+    //Process skip_list
+    if (ocConfig.skip_list !== undefined) {
+      let excludeRules = ocConfig.skip_list.filter(rule => ocLinterRules.includes(rule));
+      excludeRules.forEach(rule => {
+        if (filteredRules.includes(rule)) {
+          filteredRules = filteredRules.filter(r => r !== rule);
+        }
+      });
+    }
+    //Process exclude_paths
+    linterConfigured.exclude_paths = ocConfig.exclude_paths;
+  } catch (err) {
+    console.log(err);
+  }
+}
+
 async function updateDiagnostics(document: vscode.TextDocument, collection: vscode.DiagnosticCollection): Promise<void> {
   if ((document && path.basename(document.uri.fsPath) === "operator-config.yaml") || path.basename(document.uri.fsPath) === "operator-config.yml") {
+    if (linterConfigured === undefined) {
+      configureLinter(path.join(path.dirname(document.uri.fsPath), ".oc-lint"));
+    }
+    //Handle excludePaths
+    if (
+      linterConfigured.exclude_paths?.some(path => {
+        const minimatch = new Minimatch(path);
+        return minimatch.match(document.uri.fsPath);
+      })
+    ) {
+      collection.clear();
+      return;
+    }
+
     const configData = document.getText();
     const diagnostics: vscode.Diagnostic[] = [];
     const operatorConfig = yaml.load(configData) as OperatorConfig;
@@ -714,6 +782,7 @@ async function updateDiagnostics(document: vscode.TextDocument, collection: vsco
     //Try to read the galaxy.yml or galaxy.yaml document
     let galaxyData;
     let galaxyConfig;
+
     try {
       galaxyData = fs.readFileSync(path.join(path.dirname(document.uri.fsPath), "galaxy.yaml"), "utf8");
       galaxyConfig = yaml.load(galaxyData) as AnsibleGalaxyYmlSchema;
@@ -723,11 +792,13 @@ async function updateDiagnostics(document: vscode.TextDocument, collection: vsco
         galaxyData = fs.readFileSync(path.join(path.dirname(document.uri.fsPath), "galaxy.yml"), "utf8");
         galaxyConfig = yaml.load(galaxyData) as AnsibleGalaxyYmlSchema;
       } catch (err) {
-        diagnostics.push({
-          range: new vscode.Range(document.positionAt(0), document.positionAt(0)),
-          message: "Missing galaxy.yaml file.",
-          severity: vscode.DiagnosticSeverity.Error,
-        });
+        if (filteredRules.includes("missing-galaxy")) {
+          diagnostics.push({
+            range: new vscode.Range(document.positionAt(0), document.positionAt(0)),
+            message: "Missing galaxy.yaml file.",
+            severity: vscode.DiagnosticSeverity.Error,
+          });
+        }
       }
     }
 
@@ -747,53 +818,63 @@ async function updateDiagnostics(document: vscode.TextDocument, collection: vsco
 
     //If we succesfuly read the galaxy data we proceed to lint those features
     if (galaxyConfig !== undefined) {
-      //Validate that operatorConfig values name, version, and domain match galaxy name, version, and namespace
-      if (galaxyConfig.namespace && operatorConfig.domain && galaxyConfig.namespace.toLowerCase() !== operatorConfig.domain.toLowerCase()) {
-        //Get domain symbol
-        const domainSymbol: vscode.DocumentSymbol | undefined = docSymbols.find((symbol: vscode.DocumentSymbol) => symbol.name === "domain" && symbol.detail === operatorConfig.domain);
-        if (domainSymbol) {
-          diagnostics.push({
-            range: domainSymbol.range,
-            message: "Domain SHOULD match the namespace value specified in your galaxy.yml file, unless a fork/clone of an official Ansible Collection is desired.",
-            severity: vscode.DiagnosticSeverity.Warning,
-          });
+      if (filteredRules.includes("match-domain")) {
+        //Validate that operatorConfig values name, version, and domain match galaxy name, version, and namespace
+        if (galaxyConfig.namespace && operatorConfig.domain && galaxyConfig.namespace.toLowerCase() !== operatorConfig.domain.toLowerCase()) {
+          //Get domain symbol
+          const domainSymbol: vscode.DocumentSymbol | undefined = docSymbols.find((symbol: vscode.DocumentSymbol) => symbol.name === "domain" && symbol.detail === operatorConfig.domain);
+          if (domainSymbol) {
+            diagnostics.push({
+              range: domainSymbol.range,
+              message: "Domain SHOULD match the namespace value specified in your galaxy.yml file, unless a fork/clone of an official Ansible Collection is desired.",
+              severity: vscode.DiagnosticSeverity.Warning,
+            });
+          }
         }
       }
-      if (galaxyConfig.name && operatorConfig.name && galaxyConfig.name.toLowerCase().replace(/_/g, "-") !== operatorConfig.name.toLowerCase().replace(/_/g, "-")) {
-        //Get name symbol
-        const nameSymbol: vscode.DocumentSymbol | undefined = docSymbols.find((symbol: vscode.DocumentSymbol) => symbol.name === "name" && symbol.detail === operatorConfig.name);
-        if (nameSymbol) {
-          diagnostics.push({
-            range: nameSymbol.range,
-            message: "Name SHOULD match the name specified in your galaxy.yml file, unless a fork/clone of an official Ansible Collection is desired.",
-            severity: vscode.DiagnosticSeverity.Warning,
-          });
+
+      if (filteredRules.includes("match-name")) {
+        if (galaxyConfig.name && operatorConfig.name && galaxyConfig.name.toLowerCase().replace(/_/g, "-") !== operatorConfig.name.toLowerCase().replace(/_/g, "-")) {
+          //Get name symbol
+          const nameSymbol: vscode.DocumentSymbol | undefined = docSymbols.find((symbol: vscode.DocumentSymbol) => symbol.name === "name" && symbol.detail === operatorConfig.name);
+          if (nameSymbol) {
+            diagnostics.push({
+              range: nameSymbol.range,
+              message: "Name SHOULD match the name specified in your galaxy.yml file, unless a fork/clone of an official Ansible Collection is desired.",
+              severity: vscode.DiagnosticSeverity.Warning,
+            });
+          }
         }
       }
-      if (galaxyConfig.version && operatorConfig.version && galaxyConfig.version !== operatorConfig.version) {
-        //Get version symbol
-        const versionSymbol: vscode.DocumentSymbol | undefined = docSymbols.find((symbol: vscode.DocumentSymbol) => symbol.name === "version" && symbol.detail === operatorConfig.version);
-        if (versionSymbol) {
-          diagnostics.push({
-            range: versionSymbol.range,
-            message: "Version SHOULD match the version specified in your galaxy.yml file.",
-            severity: vscode.DiagnosticSeverity.Error,
-          });
+
+      if (filteredRules.includes("match-version")) {
+        if (galaxyConfig.version && operatorConfig.version && galaxyConfig.version !== operatorConfig.version) {
+          //Get version symbol
+          const versionSymbol: vscode.DocumentSymbol | undefined = docSymbols.find((symbol: vscode.DocumentSymbol) => symbol.name === "version" && symbol.detail === operatorConfig.version);
+          if (versionSymbol) {
+            diagnostics.push({
+              range: versionSymbol.range,
+              message: "Version SHOULD match the version specified in your galaxy.yml file.",
+              severity: vscode.DiagnosticSeverity.Error,
+            });
+          }
         }
       }
     }
 
-    //Validate that an ansible config file does not exist or that it's listed in the build_ignore section of the galaxy.yml file
-    try {
-      fs.readFileSync(path.join(path.dirname(document.uri.fsPath), "ansible.cfg"), "utf8");
-      if (!(galaxyConfig !== undefined && galaxyConfig.build_ignore?.find(ignore => ignore === "ansible.cfg"))) {
-        diagnostics.push({
-          range: new vscode.Range(document.positionAt(0), document.positionAt(0)),
-          message: "Collection build MUST not contain an ansible.cfg file. Please delete it or add this file to the build_ignore section of the galaxy.yml file.",
-          severity: vscode.DiagnosticSeverity.Error,
-        });
-      }
-    } catch (err) {}
+    if (filteredRules.includes("ansible-config")) {
+      //Validate that an ansible config file does not exist or that it's listed in the build_ignore section of the galaxy.yml file
+      try {
+        fs.readFileSync(path.join(path.dirname(document.uri.fsPath), "ansible.cfg"), "utf8");
+        if (!(galaxyConfig !== undefined && galaxyConfig.build_ignore?.find(ignore => ignore === "ansible.cfg"))) {
+          diagnostics.push({
+            range: new vscode.Range(document.positionAt(0), document.positionAt(0)),
+            message: "Collection build MUST not contain an ansible.cfg file. Please delete it or add this file to the build_ignore section of the galaxy.yml file.",
+            severity: vscode.DiagnosticSeverity.Error,
+          });
+        }
+      } catch (err) {}
+    }
 
     //Validate that playbook and finalizer paths exist
     if (operatorConfig.resources) {
@@ -811,46 +892,53 @@ async function updateDiagnostics(document: vscode.TextDocument, collection: vsco
           const resourcePlaybookSymbol = resourceSymbol?.children.find((symbol: vscode.DocumentSymbol) => symbol.name === "playbook" && symbol.detail === resource.playbook);
           //Check if path is absolute
           if (path.isAbsolute(resource.playbook)) {
-            if (resourcePlaybookSymbol) {
-              diagnostics.push({
-                range: resourcePlaybookSymbol.range,
-                message: `Playbook path MUST be relative to the root of the Operator Collection - ${resource.playbook}`,
-                severity: vscode.DiagnosticSeverity.Error,
-              });
+            if (filteredRules.includes("playbook-path")) {
+              if (resourcePlaybookSymbol) {
+                diagnostics.push({
+                  range: resourcePlaybookSymbol.range,
+                  message: `Playbook path MUST be relative to the root of the Operator Collection - ${resource.playbook}`,
+                  severity: vscode.DiagnosticSeverity.Error,
+                });
+              }
             }
           } else {
             //Check if playbook exist
             try {
               fs.readFileSync(path.join(path.dirname(document.uri.fsPath), resource.playbook), "utf8");
               const playbookDoc = await vscode.workspace.openTextDocument(path.join(path.dirname(document.uri.fsPath), resource.playbook));
-              //Get playbook "symbols"
-              const playbookDocSymbols = (await vscode.commands.executeCommand("vscode.executeDocumentSymbolProvider", playbookDoc.uri)) as vscode.DocumentSymbol[];
-              if (playbookDocSymbols !== undefined) {
-                let plays: vscode.DocumentSymbol[] = [];
 
-                playbookDocSymbols.forEach(symbol => {
-                  const play = symbol.children.find(childSymbol => childSymbol.name === "hosts");
-                  if (play) {
-                    plays.push(play);
-                  }
-                });
-                if (plays.some(play => play.detail !== "all")) {
-                  if (resourcePlaybookSymbol) {
-                    diagnostics.push({
-                      range: resourcePlaybookSymbol.range,
-                      message: `Playbook MUST use a "hosts: all" value. - ${resource.playbook}`,
-                      severity: vscode.DiagnosticSeverity.Error,
-                    });
+              if (filteredRules.includes("hosts-all")) {
+                //Get playbook "symbols"
+                const playbookDocSymbols = (await vscode.commands.executeCommand("vscode.executeDocumentSymbolProvider", playbookDoc.uri)) as vscode.DocumentSymbol[];
+                if (playbookDocSymbols !== undefined) {
+                  let plays: vscode.DocumentSymbol[] = [];
+
+                  playbookDocSymbols.forEach(symbol => {
+                    const play = symbol.children.find(childSymbol => childSymbol.name === "hosts");
+                    if (play) {
+                      plays.push(play);
+                    }
+                  });
+                  if (plays.some(play => play.detail !== "all")) {
+                    if (resourcePlaybookSymbol) {
+                      diagnostics.push({
+                        range: resourcePlaybookSymbol.range,
+                        message: `Playbook MUST use a "hosts: all" value. - ${resource.playbook}`,
+                        severity: vscode.DiagnosticSeverity.Error,
+                      });
+                    }
                   }
                 }
               }
             } catch (err) {
-              if (resourcePlaybookSymbol) {
-                diagnostics.push({
-                  range: resourcePlaybookSymbol.range,
-                  message: `Invalid Playbook for Kind ${resource.kind} - ${resource.playbook}`,
-                  severity: vscode.DiagnosticSeverity.Error,
-                });
+              if (filteredRules.includes("missing-playbook")) {
+                if (resourcePlaybookSymbol) {
+                  diagnostics.push({
+                    range: resourcePlaybookSymbol.range,
+                    message: `Invalid Playbook for Kind ${resource.kind} - ${resource.playbook}`,
+                    severity: vscode.DiagnosticSeverity.Error,
+                  });
+                }
               }
             }
           }
@@ -861,23 +949,27 @@ async function updateDiagnostics(document: vscode.TextDocument, collection: vsco
           const resourceFinalizerymbol = resourceSymbol?.children.find((symbol: vscode.DocumentSymbol) => symbol.name === "finalizer" && symbol.detail === resource.finalizer);
           //Check if path is absolute
           if (path.isAbsolute(resource.finalizer)) {
-            if (resourceFinalizerymbol) {
-              diagnostics.push({
-                range: resourceFinalizerymbol.range,
-                message: `Finalizer playbook path MUST be relative to the root of the Operator Collection - ${resource.finalizer}`,
-                severity: vscode.DiagnosticSeverity.Error,
-              });
-            }
-          } else {
-            try {
-              fs.readFileSync(path.join(path.dirname(document.uri.fsPath), resource.finalizer), "utf8");
-            } catch (err) {
+            if (filteredRules.includes("finalizer-path")) {
               if (resourceFinalizerymbol) {
                 diagnostics.push({
                   range: resourceFinalizerymbol.range,
-                  message: `Invalid Finalizer for Kind ${resource.kind} - ${resource.playbook}`,
+                  message: `Finalizer playbook path MUST be relative to the root of the Operator Collection - ${resource.finalizer}`,
                   severity: vscode.DiagnosticSeverity.Error,
                 });
+              }
+            }
+          } else {
+            if (filteredRules.includes("missing-finalizer")) {
+              try {
+                fs.readFileSync(path.join(path.dirname(document.uri.fsPath), resource.finalizer), "utf8");
+              } catch (err) {
+                if (resourceFinalizerymbol) {
+                  diagnostics.push({
+                    range: resourceFinalizerymbol.range,
+                    message: `Invalid Finalizer for Kind ${resource.kind} - ${resource.playbook}`,
+                    severity: vscode.DiagnosticSeverity.Error,
+                  });
+                }
               }
             }
           }
@@ -887,6 +979,11 @@ async function updateDiagnostics(document: vscode.TextDocument, collection: vsco
 
     collection.set(document.uri, diagnostics);
   } else {
+    //reuse the subscriptions to update the linter config if .oc-lint changes
+    if (document && path.basename(document.uri.fsPath) === ".oc-lint") {
+      configureLinter(path.join(path.dirname(document.uri.fsPath), ".oc-lint"));
+    }
+
     collection.clear();
   }
 }


### PR DESCRIPTION
FIXES:https://github.com/IBM/operator-collection-sdk-vscode-extension/issues/72
Added support of linter configuration/ignore file `.oc-lint` , it's based on the `ansible-lint-ignore` format

example:
<img width="347" alt="image" src="https://github.com/IBM/operator-collection-sdk-vscode-extension/assets/117455270/8b0f7dc3-9ba2-49eb-b51e-4244eba073e1">

