### PR TITLE
Added ability to copy error message from toast notification

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -7,6 +7,7 @@ import * as vscode from "vscode";
 import * as util from "./utilities/util";
 import * as path from "path";
 import * as fs from "fs";
+import { showErrorMessage } from "./utilities/toastModifiers";
 import { VSCodeCommands, VSCodeViewIds } from "./utilities/commandConstants";
 import { OperatorsTreeProvider } from "./treeViews/providers/operatorProvider";
 import { OperatorItem } from "./treeViews/operatorItems/operatorItem";
@@ -134,7 +135,7 @@ export async function activate(context: vscode.ExtensionContext) {
           aboutProvider.refresh();
         })
         .catch(e => {
-          vscode.window.showErrorMessage(`Failure updating session: ${e}`);
+          showErrorMessage(`Failure updating session: ${e}`);
         });
     })
   );
@@ -148,7 +149,7 @@ export async function activate(context: vscode.ExtensionContext) {
           }
         })
         .catch(e => {
-          vscode.window.showErrorMessage(`Failure updating session: ${e}`);
+          showErrorMessage(`Failure updating session: ${e}`);
         });
     })
   );
@@ -163,7 +164,7 @@ export async function activate(context: vscode.ExtensionContext) {
           aboutProvider.refresh();
         })
         .catch(e => {
-          vscode.window.showErrorMessage(`Failure updating session: ${e}`);
+          showErrorMessage(`Failure updating session: ${e}`);
         });
     })
   );
@@ -177,7 +178,7 @@ export async function activate(context: vscode.ExtensionContext) {
           }
         })
         .catch(e => {
-          vscode.window.showErrorMessage(`Failure updating session: ${e}`);
+          showErrorMessage(`Failure updating session: ${e}`);
         });
     })
   );
@@ -191,7 +192,7 @@ export async function activate(context: vscode.ExtensionContext) {
           }
         })
         .catch(e => {
-          vscode.window.showErrorMessage(`Failure updating session: ${e}`);
+          showErrorMessage(`Failure updating session: ${e}`);
         });
     })
   );
@@ -205,7 +206,7 @@ export async function activate(context: vscode.ExtensionContext) {
           }
         })
         .catch(e => {
-          vscode.window.showErrorMessage(`Failure updating session: ${e}`);
+          showErrorMessage(`Failure updating session: ${e}`);
         });
     })
   );
@@ -244,7 +245,7 @@ function installOcSdk(command: string, ocSdkCmd: OcSdkCommand, session: Session,
           vscode.commands.executeCommand(VSCodeCommands.refresh);
         })
         .catch(e => {
-          vscode.window.showErrorMessage(`Failure installing the IBM Operator Collection SDK: ${e}`);
+          showErrorMessage(`Failure installing the IBM Operator Collection SDK: ${e}`);
         });
     }
   });
@@ -263,10 +264,10 @@ function updateOcSdkVersion(command: string, ocSdkCmd: OcSdkCommand, session: Se
           vscode.commands.executeCommand(VSCodeCommands.refreshAll);
         })
         .catch(e => {
-          vscode.window.showErrorMessage(`Failure upgrading to the latest IBM Operator Collection SDK: ${e}`);
+          showErrorMessage(`Failure upgrading to the latest IBM Operator Collection SDK: ${e}`);
         });
     } catch (e) {
-      vscode.window.showErrorMessage(`Failure upgrading the IBM Operator Collection SDK: ${e}`);
+      showErrorMessage(`Failure upgrading the IBM Operator Collection SDK: ${e}`);
       vscode.commands.executeCommand("setContext", VSCodeCommands.sdkOutdatedVersion, await session.determinateOcSdkIsOutdated());
       vscode.commands.executeCommand(VSCodeCommands.refresh);
     }
@@ -333,13 +334,13 @@ function updateProject(command: string, ocCmd: OcCommand, session: Session, outp
                 vscode.commands.executeCommand(VSCodeCommands.refreshAll);
               })
               .catch(e => {
-                vscode.window.showErrorMessage(`Failure updating Project on OpenShift cluster: ${e}`);
+                showErrorMessage(`Failure updating Project on OpenShift cluster: ${e}`);
               });
           }
         }
       })
       .catch(e => {
-        vscode.window.showErrorMessage(`Failure updating session: ${e}`);
+        showErrorMessage(`Failure updating session: ${e}`);
       });
   });
 }
@@ -362,7 +363,7 @@ function logIn(command: string, ocCmd: OcCommand, session: Session, outputChanne
         })
         .catch(e => {
           session.loggedIntoOpenShift = false;
-          vscode.window.showErrorMessage(`Failure logging into OpenShift cluster: ${e}`);
+          showErrorMessage(`Failure logging into OpenShift cluster: ${e}`);
         });
     }
   });
@@ -384,7 +385,7 @@ function logOut(command: string, ocCmd: OcCommand, session: Session): vscode.Dis
           vscode.commands.executeCommand(VSCodeCommands.refreshAll);
         })
         .catch(e => {
-          vscode.window.showErrorMessage(`Failure logging out of OpenShift cluster: ${e}`);
+          showErrorMessage(`Failure logging out of OpenShift cluster: ${e}`);
         });
     }
   });
@@ -398,7 +399,7 @@ function executeOpenLinkCommand(command: string): vscode.Disposable {
       try {
         await vscode.env.openExternal(linkUri);
       } catch (e) {
-        vscode.window.showErrorMessage(`Failure opening external link: ${e}`);
+        showErrorMessage(`Failure opening external link: ${e}`);
       }
     } else {
       vscode.window.showWarningMessage("Unable to open link while tree view is refreshing. Please try again in a few seconds.");
@@ -449,7 +450,7 @@ function viewResourceCommand(command: string, session: Session): vscode.Disposab
         }
       })
       .catch(e => {
-        vscode.window.showErrorMessage(`Failure updating session: ${e}`);
+        showErrorMessage(`Failure updating session: ${e}`);
       });
   });
 }
@@ -474,7 +475,7 @@ function executeContainerViewLogCommand(command: string, session: Session): vsco
         }
       })
       .catch(e => {
-        vscode.window.showErrorMessage(`Failure updating session: ${e}`);
+        showErrorMessage(`Failure updating session: ${e}`);
       });
   });
 }
@@ -490,7 +491,7 @@ function executeCustomResourceViewLogCommand(command: string, session: Session):
           let podName: string = "";
           let containerName: string = "";
           if (operatorItem?.podItems.length === 0) {
-            vscode.window.showErrorMessage("Failure retrieving logs because operator pod doesn't exist");
+            showErrorMessage("Failure retrieving logs because operator pod doesn't exist");
             return;
           }
           const podItem = operatorItem?.podItems.find(item => {
@@ -515,10 +516,10 @@ function executeCustomResourceViewLogCommand(command: string, session: Session):
               }
             }
             if (podName === "") {
-              vscode.window.showErrorMessage("Unabled to determine Pod name for corresponding instance");
+              showErrorMessage("Unabled to determine Pod name for corresponding instance");
               return;
             } else if (containerName === "") {
-              vscode.window.showErrorMessage("Unabled to determine container name for corresponding instance");
+              showErrorMessage("Unabled to determine container name for corresponding instance");
               return;
             } else {
               const logUri = util.buildVerboseContainerLogUri(podName, containerName, customResourcesItemArgs.customResourceObj.apiVersion.split("/")[1], customResourcesItemArgs.customResourceObj.kind, customResourcesItemArgs.customResourceObj.metadata.name);
@@ -539,7 +540,7 @@ function executeCustomResourceViewLogCommand(command: string, session: Session):
         }
       })
       .catch(e => {
-        vscode.window.showErrorMessage(`Failure updating session: ${e}`);
+        showErrorMessage(`Failure updating session: ${e}`);
       });
   });
 }
@@ -589,7 +590,7 @@ function executeSimpleSdkCommand(command: string, session: Session, outputChanne
                     })
                     .catch(e => {
                       session.operationPending = false;
-                      vscode.window.showErrorMessage(`Failure executing Delete Operator command: RC ${e}`);
+                      showErrorMessage(`Failure executing Delete Operator command: RC ${e}`);
                     });
                   break;
                 }
@@ -599,7 +600,7 @@ function executeSimpleSdkCommand(command: string, session: Session, outputChanne
                   const operatorVersion = await util.getOperatorConfigVersion(workspacePath);
                   if (operatorVersion === undefined) {
                     session.operationPending = false;
-                    vscode.window.showErrorMessage(`Failure retrieve version from operator config`);
+                    showErrorMessage(`Failure retrieve version from operator config`);
                     return;
                   }
                   const signatureValidationRequired = await k8s.signatureValidationRequiredForOperator(operatorName, operatorVersion);
@@ -608,7 +609,7 @@ function executeSimpleSdkCommand(command: string, session: Session, outputChanne
                     return;
                   } else if (signatureValidationRequired) {
                     session.operationPending = false;
-                    vscode.window.showErrorMessage(`Unable to redeploy collection when signature validation is required. Execute the Redeploy Operator action to reconfigure the operator and disable signature validation`);
+                    showErrorMessage(`Unable to redeploy collection when signature validation is required. Execute the Redeploy Operator action to reconfigure the operator and disable signature validation`);
                     return;
                   }
                   vscode.window.showInformationMessage("Redeploy Collection request in progress");
@@ -624,7 +625,7 @@ function executeSimpleSdkCommand(command: string, session: Session, outputChanne
                     })
                     .catch(e => {
                       session.operationPending = false;
-                      vscode.window.showErrorMessage(`Failure executing Redeploy Collection command: RC ${e}`);
+                      showErrorMessage(`Failure executing Redeploy Collection command: RC ${e}`);
                     });
                   break;
                 }
@@ -642,7 +643,7 @@ function executeSimpleSdkCommand(command: string, session: Session, outputChanne
                     })
                     .catch(e => {
                       session.operationPending = false;
-                      vscode.window.showErrorMessage(`Failure executing Redeploy Operator command: RC ${e}`);
+                      showErrorMessage(`Failure executing Redeploy Operator command: RC ${e}`);
                     });
                   break;
                 }
@@ -652,7 +653,7 @@ function executeSimpleSdkCommand(command: string, session: Session, outputChanne
         }
       })
       .catch(e => {
-        vscode.window.showErrorMessage(`Failure updating session: ${e}`);
+        showErrorMessage(`Failure updating session: ${e}`);
       });
   });
 }
@@ -707,7 +708,7 @@ function executeSdkCommandWithUserInput(command: string, session: Session, outpu
                   })
                   .catch(e => {
                     session.operationPending = false;
-                    vscode.window.showErrorMessage(`Failure executing Create Operator command: RC ${e}`);
+                    showErrorMessage(`Failure executing Create Operator command: RC ${e}`);
                   });
               }
             }
@@ -740,20 +741,20 @@ function deleteCustomResource(command: string, session: Session) {
                     vscode.window.showInformationMessage(`Successfully deleted ${kind} resource`);
                     vscode.commands.executeCommand(VSCodeCommands.resourceRefresh);
                   } else {
-                    vscode.window.showErrorMessage(`Failed to delete ${kind} resource`);
+                    showErrorMessage(`Failed to delete ${kind} resource`);
                   }
                 })
                 .catch(e => {
-                  vscode.window.showErrorMessage(`Failed to delete ${kind} resource: ${e}`);
+                  showErrorMessage(`Failed to delete ${kind} resource: ${e}`);
                 });
             }
           } else {
-            vscode.window.showErrorMessage("Failed to delete custom resource. Please try again.");
+            showErrorMessage("Failed to delete custom resource. Please try again.");
           }
         }
       })
       .catch(e => {
-        vscode.window.showErrorMessage(`Failure updating session: ${e}`);
+        showErrorMessage(`Failure updating session: ${e}`);
       });
   });
 }

--- a/src/kubernetes/kubernetes.ts
+++ b/src/kubernetes/kubernetes.ts
@@ -8,7 +8,8 @@ import * as k8s from "@kubernetes/client-node";
 import * as util from "../utilities/util";
 import { OcCommand } from "../shellCommands/ocCommand";
 import { KubernetesContext } from "./kubernetesContext";
-import { VSCodeCommands, CustomResourcePhases } from "../utilities/commandConstants";
+import { CustomResourcePhases } from "../utilities/commandConstants";
+import { showErrorMessage } from "../utilities/toastModifiers";
 
 export interface ObjectList {
   apiVersion: string;
@@ -99,7 +100,7 @@ export class KubernetesObj extends KubernetesContext {
       .catch(e => {
         const msg = `Failure retrieving Pods in namespace. ${JSON.stringify(e)}`;
         console.error(msg);
-        vscode.window.showErrorMessage(msg);
+        showErrorMessage(msg);
         return undefined;
       });
   }
@@ -190,7 +191,7 @@ export class KubernetesObj extends KubernetesContext {
         }
         const msg = `Failure retrieving Pod logs. ${JSON.stringify(e)}`;
         console.error(msg);
-        vscode.window.showErrorMessage(msg);
+        showErrorMessage(msg);
         return undefined;
       });
   }
@@ -220,7 +221,7 @@ export class KubernetesObj extends KubernetesContext {
           vscode.window.showWarningMessage("Ansible-Runner task logs not yet generated for Custom Resource instance");
           return undefined;
         } else {
-          vscode.window.showErrorMessage(msg);
+          showErrorMessage(msg);
           return undefined;
         }
       });
@@ -247,7 +248,7 @@ export class KubernetesObj extends KubernetesContext {
         } else {
           const msg = `Failure retrieving Custom Resource list. ${e.response.statusMessage}`;
           console.error(msg);
-          vscode.window.showErrorMessage(msg);
+          showErrorMessage(msg);
           return undefined;
         }
       });
@@ -273,7 +274,7 @@ export class KubernetesObj extends KubernetesContext {
           } else {
             const msg = `Failure deleting Custom Resource object. ${e.response.statusMessage}`;
             console.error(msg);
-            vscode.window.showErrorMessage(msg);
+            showErrorMessage(msg);
             return false;
           }
         });
@@ -337,7 +338,7 @@ export class KubernetesObj extends KubernetesContext {
           } else {
             const msg = `Failure retrieving Broker object list. ${JSON.stringify(e)}`;
             console.error(msg);
-            vscode.window.showErrorMessage(msg);
+            showErrorMessage(msg);
             return undefined;
           }
         });
@@ -356,7 +357,7 @@ export class KubernetesObj extends KubernetesContext {
           } else {
             const msg = `Failure retrieving Broker object list. ${JSON.stringify(e)}`;
             console.error(msg);
-            vscode.window.showErrorMessage(msg);
+            showErrorMessage(msg);
             return undefined;
           }
         });
@@ -380,7 +381,7 @@ export class KubernetesObj extends KubernetesContext {
       .catch(e => {
         const msg = `Failure retrieving custom resource object. ${JSON.stringify(e)}`;
         console.error(msg);
-        vscode.window.showErrorMessage(msg);
+        showErrorMessage(msg);
         return undefined;
       });
   }
@@ -415,7 +416,7 @@ export class KubernetesObj extends KubernetesContext {
         } else {
           const msg = `Failure retrieving Custom Resource instance names. ${JSON.stringify(e)}`;
           console.error(msg);
-          vscode.window.showErrorMessage(msg);
+          showErrorMessage(msg);
           return undefined;
         }
       });
@@ -465,7 +466,7 @@ export class KubernetesObj extends KubernetesContext {
       .catch(e => {
         const msg: any = `Failure retrieving ClusterServiceVersion. ${e}`;
         console.error(msg);
-        vscode.window.showErrorMessage(msg.toString());
+        showErrorMessage(msg.toString());
         throw new Error(msg);
       });
   }
@@ -596,7 +597,7 @@ export class KubernetesObj extends KubernetesContext {
         if (e.statusCode !== 403 && e.statusCode !== 401) {
           const msg = `Failure retrieving Namespace list: ${JSON.stringify(e)}`;
           console.error(msg);
-          vscode.window.showErrorMessage(msg);
+          showErrorMessage(msg);
         }
         return undefined;
       });
@@ -636,10 +637,10 @@ export class KubernetesObj extends KubernetesContext {
         const objsString = JSON.stringify(res.body);
         const objsList: ObjectList = JSON.parse(objsString);
         if (objsList.items.length === 0) {
-          vscode.window.showErrorMessage("OperatorCollection resource not detected in namespace");
+          showErrorMessage("OperatorCollection resource not detected in namespace");
           return undefined;
         } else if (objsList.items.length > 1) {
-          vscode.window.showErrorMessage("Duplicate OperatorCollection resources detected in namespace");
+          showErrorMessage("Duplicate OperatorCollection resources detected in namespace");
           return undefined;
         } else {
           const operatorCollection: OperatorCollectionInstance = objsList.items[0];
@@ -653,7 +654,7 @@ export class KubernetesObj extends KubernetesContext {
       .catch(e => {
         const msg = `Failure retrieving OperatorCollections list. ${JSON.stringify(e)}`;
         console.error(msg);
-        vscode.window.showErrorMessage(msg);
+        showErrorMessage(msg);
         return undefined;
       });
   }

--- a/src/kubernetes/kubernetesContext.ts
+++ b/src/kubernetes/kubernetesContext.ts
@@ -4,6 +4,7 @@ import * as k8s from "@kubernetes/client-node";
 import * as fs from "fs";
 import { VSCodeCommands } from "../utilities/commandConstants";
 import { OcCommand } from "../shellCommands/ocCommand";
+import { showErrorMessage } from "../utilities/toastModifiers";
 
 export class KubernetesContext {
   public coreV1Api: k8s.CoreV1Api | undefined = undefined;
@@ -54,7 +55,7 @@ export class KubernetesContext {
         this.coreV1Api = kc.makeApiClient(k8s.CoreV1Api);
         this.customObjectsApi = kc.makeApiClient(k8s.CustomObjectsApi);
       } catch (error) {
-        vscode.window.showErrorMessage(`Failed to validate KubeConfig file. ${error}`);
+        showErrorMessage(`Failed to validate KubeConfig file. ${error}`);
         vscode.window.showInformationMessage("Please log into the OpenShift cluster again.");
       }
     }
@@ -76,7 +77,7 @@ export class KubernetesContext {
           vscode.commands.executeCommand(VSCodeCommands.refreshAll);
           resolve(true);
         } catch (error) {
-          vscode.window.showErrorMessage(`Failure logging in to OpenShift cluster: ${error}`);
+          showErrorMessage(`Failure logging in to OpenShift cluster: ${error}`);
           reject(false);
         }
       } else {

--- a/src/shellCommands/ocSdkCommands.ts
+++ b/src/shellCommands/ocSdkCommands.ts
@@ -9,6 +9,7 @@ import * as fs from "fs-extra";
 import * as https from "https";
 import * as http from "http";
 import { getAnsibleGalaxySettings, AnsibleGalaxySettings } from "../utilities/util";
+import { showErrorMessage } from "../utilities/toastModifiers";
 
 type HTTP = typeof http;
 type HTTPS = typeof https;
@@ -137,7 +138,7 @@ export class OcSdkCommand {
       if (pipVersion) {
         moduleStatusCode = await this.run(pipVersion, ["install", "kubernetes"], outputChannel, logPath);
       } else {
-        vscode.window.showErrorMessage('Failed to install python module "kubernetes": pip/pip3 is not installed');
+        showErrorMessage('Failed to install python module "kubernetes": pip/pip3 is not installed');
       }
 
       const galaxyUrl = getAnsibleGalaxySettings(AnsibleGalaxySettings.ansibleGalaxyURL) as string;
@@ -207,7 +208,7 @@ export class OcSdkCommand {
     try {
       jsonData = await getJsonData(galaxyUrl, galaxyNamespace);
     } catch (e) {
-      vscode.window.showErrorMessage(`Failure retrieving data from Ansible Galaxy: ${e}`);
+      showErrorMessage(`Failure retrieving data from Ansible Galaxy: ${e}`);
     }
 
     const latestVersion = getLatestCollectionVersion(jsonData);

--- a/src/treeViews/providers/operatorProvider.ts
+++ b/src/treeViews/providers/operatorProvider.ts
@@ -9,6 +9,7 @@ import { OperatorPodItem, getOperatorPodItems } from "../operatorItems/operatorP
 import { getOperatorContainerItems } from "../operatorItems/operatorContainerItem";
 import { OperatorTreeItem } from "../operatorItems/operatorTreeItems";
 import { Session } from "../../utilities/session";
+import { showErrorMessage } from "../../utilities/toastModifiers";
 
 type TreeItem = OperatorTreeItem | undefined | void;
 
@@ -39,7 +40,7 @@ export class OperatorsTreeProvider implements vscode.TreeDataProvider<OperatorTr
               return operatorPodItems;
             })
             .catch(e => {
-              vscode.window.showErrorMessage(`Failure retrieving pods list: ${e}`);
+              showErrorMessage(`Failure retrieving pods list: ${e}`);
               return [];
             });
         } else if (element instanceof OperatorPodItem) {

--- a/src/utilities/toastModifiers.ts
+++ b/src/utilities/toastModifiers.ts
@@ -1,0 +1,18 @@
+import * as vscode from "vscode";
+
+const toastActions = {
+  copy: { title: "copy", isCloseAffordance: false },
+};
+
+/**
+ * Displays error message toast with copy button that allows users to copy the error message
+ * @param message - Message to be displayed in the toast notification.
+ * @returns
+ */
+export function showErrorMessage(message: string, ...items: any[]) {
+  vscode.window.showErrorMessage(message, toastActions.copy, ...items).then(selection => {
+    if (selection === toastActions.copy) {
+      vscode.env.clipboard.writeText(message);
+    }
+  });
+}

--- a/src/utilities/util.ts
+++ b/src/utilities/util.ts
@@ -11,6 +11,7 @@ import * as yaml from "js-yaml";
 import { setInterval } from "timers";
 import { KubernetesObj } from "../kubernetes/kubernetes";
 import { VSCodeCommands } from "../utilities/commandConstants";
+import { showErrorMessage } from "./toastModifiers";
 
 type WorkSpaceOperators = { [key: string]: string };
 
@@ -174,7 +175,7 @@ function getOperatorConfigUri(pwd: string): vscode.Uri {
   } else if (fs.existsSync(path.join(pwd, "operator-config.yaml"))) {
     operatorConfigFilePath = path.join(pwd, "operator-config.yaml");
   } else {
-    vscode.window.showErrorMessage("operator-config file doesn't exist in workspace");
+    showErrorMessage("operator-config file doesn't exist in workspace");
   }
   return vscode.Uri.parse(operatorConfigFilePath);
 }
@@ -283,7 +284,7 @@ export async function requestOperatorInfo(workspacePath: string): Promise<string
     args.push(`--extra-vars "@${extraVarsFilePath}"`);
     return args;
   } else if (ocsdkVarsFile.length > 1) {
-    vscode.window.showErrorMessage("Multiple ocsdk-extra-vars files in Operator Collection not allowed");
+    showErrorMessage("Multiple ocsdk-extra-vars files in Operator Collection not allowed");
     return undefined;
   }
 
@@ -309,7 +310,7 @@ export async function requestOperatorInfo(workspacePath: string): Promise<string
   if (zosEndpointType === undefined) {
     return undefined;
   } else if (zosEndpointType === "") {
-    vscode.window.showErrorMessage("Endpoint type is required");
+    showErrorMessage("Endpoint type is required");
     return undefined;
   }
   args.push(`-e "zosendpoint_type=${zosEndpointType}"`);
@@ -322,7 +323,7 @@ export async function requestOperatorInfo(workspacePath: string): Promise<string
   if (zosEndpointName === undefined) {
     return undefined;
   } else if (zosEndpointName === "") {
-    vscode.window.showErrorMessage("ZosEndpoint Name is required");
+    showErrorMessage("ZosEndpoint Name is required");
     return undefined;
   }
 
@@ -337,7 +338,7 @@ export async function requestOperatorInfo(workspacePath: string): Promise<string
     if (zosEndpointHost === undefined) {
       return undefined;
     } else if (zosEndpointHost === "") {
-      vscode.window.showErrorMessage("ZosEndpoint host is required");
+      showErrorMessage("ZosEndpoint host is required");
       return undefined;
     }
     args.push(`-e "zosendpoint_host=${zosEndpointHost}"`);
@@ -351,7 +352,7 @@ export async function requestOperatorInfo(workspacePath: string): Promise<string
     if (zosEndpointPort === undefined) {
       return undefined;
     } else if (zosEndpointPort === "") {
-      vscode.window.showErrorMessage("ZosEndpoint port is required");
+      showErrorMessage("ZosEndpoint port is required");
       return undefined;
     }
     args.push(`-e "zosendpoint_port=${zosEndpointPort}"`);
@@ -545,7 +546,7 @@ export async function requestInitOperatorCollectionInfo(): Promise<string[] | un
     return undefined;
   } else {
     if (collectionName === "") {
-      vscode.window.showErrorMessage("Collection name is required");
+      showErrorMessage("Collection name is required");
       return undefined;
     }
   }
@@ -562,7 +563,7 @@ export async function requestInitOperatorCollectionInfo(): Promise<string[] | un
     return undefined;
   } else {
     if (ansibleGalaxyNamespace === "") {
-      vscode.window.showErrorMessage("Galaxy namespace is required");
+      showErrorMessage("Galaxy namespace is required");
       return undefined;
     }
   }
@@ -578,7 +579,7 @@ export async function requestInitOperatorCollectionInfo(): Promise<string[] | un
     return undefined;
   } else {
     if (offlineInstall === "") {
-      vscode.window.showErrorMessage("Couldn't determinate if the collection will be executed in an offline environment");
+      showErrorMessage("Couldn't determinate if the collection will be executed in an offline environment");
       return undefined;
     }
   }


### PR DESCRIPTION
All error messages that are written with `showErrorMessage` as opposed to `vscode.window.showErrorMessage` add the ability to copy the error message. Enhancement issue #10.

![Screenshot 2023-11-27 at 1 04 12 PM](https://github.com/IBM/operator-collection-sdk-vscode-extension/assets/91276489/a67d147d-104e-44c2-997b-ba9453f9bb57)
