### PR TITLE
Prevent error messages and response delays when connectivity to OpenShift and Ansible Galaxy connectivity is disrupted

### DIFF
--- a/src/kubernetes/kubernetes.ts
+++ b/src/kubernetes/kubernetes.ts
@@ -597,7 +597,6 @@ export class KubernetesObj extends KubernetesContext {
         if (e.statusCode !== 403 && e.statusCode !== 401) {
           const msg = `Failure retrieving Namespace list: ${JSON.stringify(e)}`;
           console.error(msg);
-          showErrorMessage(msg);
         }
         return undefined;
       });

--- a/src/shellCommands/ocSdkCommands.ts
+++ b/src/shellCommands/ocSdkCommands.ts
@@ -211,16 +211,19 @@ export class OcSdkCommand {
       showErrorMessage(`Failure retrieving data from Ansible Galaxy: ${e}`);
     }
 
-    const latestVersion = getLatestCollectionVersion(jsonData);
-    const versionInstalled = await this.runOcSdkVersion(outputChannel, logPath);
-
-    return new Promise<boolean>((resolve, reject) => {
-      if (latestVersion === undefined) {
-        reject("Unable to locate latest version");
-      } else if (versionInstalled === undefined) {
-        resolve(false); // return false if OC SDK isn't installed
+    return new Promise<boolean>(async (resolve, reject) => {
+      if (!jsonData.hasOwnProperty("data")) {
+        reject("Unable to retrieve data from galaxy endpoint");
       } else {
-        resolve(!(versionInstalled.trim() === latestVersion.trim()));
+        const latestVersion = getLatestCollectionVersion(jsonData);
+        const versionInstalled = await this.runOcSdkVersion(outputChannel, logPath);
+        if (latestVersion === undefined) {
+          reject("Unable to locate latest version");
+        } else if (versionInstalled === undefined) {
+          resolve(false); // return false if OC SDK isn't installed
+        } else {
+          resolve(!(versionInstalled.trim() === latestVersion.trim()));
+        }
       }
     });
   }

--- a/src/utilities/util.ts
+++ b/src/utilities/util.ts
@@ -268,6 +268,8 @@ export async function requestOperatorInfo(workspacePath: string): Promise<string
             console.error("Failure storing variables to file");
           }
         }
+      } else {
+        return undefined;
       }
     }
     args.push(`--extra-vars "@${extraVarsFilePath}"`);


### PR DESCRIPTION
There may be scenarios where a user attempts to use the extension, but the connectivity to Ansible Galaxy or OpenShift is disrupted. An example being, when a user is pointing to an internal OpenShift cluster or Ansible Galaxy server, but hasn't opened a VPN connection. This would cause API requests to timeout, which could take 60 seconds or more before responding, or receive an unexpected response.

Fixes include:
- Prevent error message from being displayed to the user when errors occur while validating connectivity to OpenShift. Instead just redirect the user to the Log In prompt
- Reject Ansible Galaxy version requests when body doesn't exist. This usually implies a connectivity issue
- Created a timeout function to cancel Namespace requests that take longer than 5 seconds. (note. Applying the `listNamespace()` `timeoutSeconds` parameter doesn't seem to work as expected....which is why I created a new timeout request)
- Added fix where users would click escape to cancel a Create Operator request that only required passphrase input, but the request would continue