### PR TITLE
Display last task failure message for redeploy operator command

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "operator-collection-sdk",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "operator-collection-sdk",
-      "version": "1.0.1",
+      "version": "1.1.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@kubernetes/client-node": "^0.18.1",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -931,7 +931,7 @@ function executeSimpleSdkCommand(command: string, session: Session, outputChanne
                     })
                     .catch(e => {
                       session.operationPending = false;
-                      showErrorMessage(`Failure executing Redeploy Collection command: RC ${e}`);
+                      showErrorMessage(`Failure executing Redeploy Collection command: ${e}`);
                     });
                   break;
                 }
@@ -949,7 +949,7 @@ function executeSimpleSdkCommand(command: string, session: Session, outputChanne
                     })
                     .catch(e => {
                       session.operationPending = false;
-                      showErrorMessage(`Failure executing Redeploy Operator command: RC ${e}`);
+                      showErrorMessage(`Failure executing Redeploy Operator command: ${e}`);
                     });
                   break;
                 }
@@ -1014,7 +1014,7 @@ function executeSdkCommandWithUserInput(command: string, session: Session, outpu
                   })
                   .catch(e => {
                     session.operationPending = false;
-                    showErrorMessage(`Failure executing Create Operator command: RC ${e}`);
+                    showErrorMessage(`Failure executing Create Operator command: ${e}`);
                   });
               }
             }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -251,7 +251,7 @@ function executeInlineReplaceWith(command: string) {
       edit.replace(document.uri, range, refactorText);
       vscode.workspace.applyEdit(edit);
     } catch (e) {
-      showErrorMessage(`Failed to edit "${path.basename(document.uri.fsPath)}": ${e}`);
+      vscode.window.showErrorMessage(`Failed to edit "${path.basename(document.uri.fsPath)}": ${e}`);
     }
   });
 }
@@ -303,7 +303,7 @@ function createFile(command: string): vscode.Disposable {
     } else if (playbookRX.test(filename)) {
       content = BoilerplateContent.playbookBoilerplateContent;
     } else {
-      showErrorMessage(`Cannot create scaffold for file ${filename}. Supported file types are: .yaml/.yml`);
+      vscode.window.showErrorMessage(`Cannot create scaffold for file ${filename}. Supported file types are: .yaml/.yml`);
       return;
     }
 
@@ -373,7 +373,7 @@ function createFile(command: string): vscode.Disposable {
         callBack();
       }
     } catch (e) {
-      showErrorMessage(`Error while attempting to create file ${filename}: ${e}`);
+      vscode.window.showErrorMessage(`Error while attempting to create file ${filename}: ${e}`);
     }
   });
 }
@@ -401,7 +401,7 @@ function createGalaxyBoilerplateFile(command: string): vscode.Disposable {
       }
       vscode.commands.executeCommand(VSCodeCommands.createFile, filename, destinationDirectory);
     } else {
-      showErrorMessage(`Failed to create ${filename} file, please try again.`);
+      vscode.window.showErrorMessage(`Failed to create ${filename} file, please try again.`);
     }
   });
 }
@@ -429,7 +429,7 @@ function createOperatorConfigBoilerplateFile(command: string): vscode.Disposable
       }
       vscode.commands.executeCommand(VSCodeCommands.createFile, filename, destinationDirectory);
     } else {
-      showErrorMessage(`Failed to create ${filename} file, please try again.`);
+      vscode.window.showErrorMessage(`Failed to create ${filename} file, please try again.`);
     }
   });
 }
@@ -441,7 +441,7 @@ function createPlaybookBoilerplateFile(command: string): vscode.Disposable {
       const directory = uri.fsPath;
       vscode.commands.executeCommand(VSCodeCommands.createFile, filename, directory);
     } else {
-      showErrorMessage(`Failed to create ${filename} file, please try again.`);
+      vscode.window.showErrorMessage(`Failed to create ${filename} file, please try again.`);
     }
   });
 }
@@ -491,7 +491,7 @@ function convertToAirgapCollection(command: string, outputChannel?: vscode.Outpu
           vscode.window.showInformationMessage(`Successfully converted \"${path.basename(nearestCollection)}\" to an airgap collection`);
         });
       } catch (e) {
-        showErrorMessage('The Operator Collection SDK command "create_offline_requirements" failed convert collection. Please see output for more details.');
+        vscode.window.showErrorMessage('The Operator Collection SDK command "create_offline_requirements" failed convert collection. Please see output for more details.');
       }
     }
   });
@@ -587,16 +587,15 @@ function initOperatorCollection(command: string, session: Session, outputChannel
         ocSdkCommand
           .runInitOperatorCollection(args, outputChannel, logPath)
           .then(async () => {
+            session.operationPending = false;
             const namespace = args[0].split("=")[1].replace(/"/, "");
             vscode.window.showInformationMessage(`Initialization of Operator Collection "${namespace}" executed successfully`);
             vscode.commands.executeCommand("setContext", VSCodeCommands.isCollectionInWorkspace, await util.isCollectionInWorkspace(session.skipOCinit));
             vscode.commands.executeCommand(VSCodeCommands.refresh);
           })
           .catch(e => {
-            showErrorMessage(`The collection initialization has unexpectedly failed. Please review the output logs for details. ${e}`);
-          })
-          .finally(() => {
             session.operationPending = false;
+            vscode.window.showErrorMessage(`The collection initialization has unexpectedly failed. Please review the output logs for details. ${e}`);
           });
       }
     }
@@ -891,14 +890,13 @@ function executeSimpleSdkCommand(command: string, session: Session, outputChanne
                   const runDeleteOperatorCommand = ocSdkCommand.runDeleteOperatorCommand(outputChannel, logPath);
                   Promise.all([poll, runDeleteOperatorCommand])
                     .then(() => {
+                      session.operationPending = false;
                       vscode.window.showInformationMessage("Delete Operator command executed successfully");
                       vscode.commands.executeCommand(VSCodeCommands.refresh);
                     })
                     .catch(e => {
-                      showErrorMessage(`Failure executing Delete Operator command: RC ${e}`);
-                    })
-                    .finally(() => {
                       session.operationPending = false;
+                      showErrorMessage(`Failure executing Delete Operator command: RC ${e}`);
                     });
                   break;
                 }
@@ -922,40 +920,36 @@ function executeSimpleSdkCommand(command: string, session: Session, outputChanne
                   }
                   vscode.window.showInformationMessage("Redeploy Collection request in progress");
                   const poll = util.pollRun(30);
-                  const runRedeployCollectionCommand = ocSdkCommand.runRedeployCollectionCommand(outputChannel, logPath);
-                  // .then(() => {
-                  //   session.operationPending = false;
-                  // });
+                  const runRedeployCollectionCommand = ocSdkCommand.runRedeployCollectionCommand(outputChannel, logPath).then(() => {
+                    session.operationPending = false;
+                  });
                   Promise.all([poll, runRedeployCollectionCommand])
                     .then(() => {
+                      session.operationPending = false;
                       vscode.window.showInformationMessage("Redeploy Collection command executed successfully");
                       vscode.commands.executeCommand(VSCodeCommands.refresh);
                     })
                     .catch(e => {
-                      showErrorMessage(`Failure executing Redeploy Collection command: RC ${e}`);
-                    })
-                    .finally(() => {
                       session.operationPending = false;
+                      showErrorMessage(`Failure executing Redeploy Collection command: RC ${e}`);
                     });
                   break;
                 }
                 case VSCodeCommands.redeployOperator: {
                   vscode.window.showInformationMessage("Redeploy Operator request in progress");
                   const poll = util.pollRun(40);
-                  const runRedeployOperatorCommand = ocSdkCommand.runRedeployOperatorCommand(outputChannel, logPath);
-                  // .then(() => {
-                  //   session.operationPending = false;
-                  // });
+                  const runRedeployOperatorCommand = ocSdkCommand.runRedeployOperatorCommand(outputChannel, logPath).then(() => {
+                    session.operationPending = false;
+                  });
                   Promise.all([poll, runRedeployOperatorCommand])
                     .then(() => {
+                      session.operationPending = false;
                       vscode.window.showInformationMessage("Redeploy Operator command executed successfully");
                       vscode.commands.executeCommand(VSCodeCommands.refresh);
                     })
                     .catch(e => {
-                      showErrorMessage(`Failure executing Redeploy Operator command: RC ${e}`);
-                    })
-                    .finally(() => {
                       session.operationPending = false;
+                      showErrorMessage(`Failure executing Redeploy Operator command: RC ${e}`);
                     });
                   break;
                 }
@@ -1009,20 +1003,18 @@ function executeSdkCommandWithUserInput(command: string, session: Session, outpu
                 session.operationPending = true;
                 Promise.all([
                   util.pollRun(40),
-                  ocSdkCommand.runCreateOperatorCommand(playbookArgs, outputChannel, logPath),
-                  // .then(() => {
-                  //   session.operationPending = false;
-                  // }),
+                  ocSdkCommand.runCreateOperatorCommand(playbookArgs, outputChannel, logPath).then(() => {
+                    session.operationPending = false;
+                  }),
                 ])
                   .then(() => {
+                    session.operationPending = false;
                     vscode.window.showInformationMessage("Create Operator command executed successfully");
                     vscode.commands.executeCommand(VSCodeCommands.refresh);
                   })
                   .catch(e => {
-                    showErrorMessage(`Failure executing Create Operator command: RC ${e}`);
-                  })
-                  .finally(() => {
                     session.operationPending = false;
+                    showErrorMessage(`Failure executing Create Operator command: RC ${e}`);
                   });
               }
             }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -896,7 +896,7 @@ function executeSimpleSdkCommand(command: string, session: Session, outputChanne
                     })
                     .catch(e => {
                       session.operationPending = false;
-                      showErrorMessage(`Failure executing Delete Operator command: RC ${e}`);
+                      showErrorMessage(`Failure executing Delete Operator command: ${e}`);
                     });
                   break;
                 }

--- a/src/kubernetes/kubernetes.ts
+++ b/src/kubernetes/kubernetes.ts
@@ -579,7 +579,7 @@ export class KubernetesObj extends KubernetesContext {
   public async getNamespaceList(): Promise<string[] | undefined> {
     const namespaceList: Array<string> = [];
     return this.coreV1Api
-      ?.listNamespace(undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, 5)
+      ?.listNamespace()
       .then(res => {
         if (res.response.statusCode === 200) {
           let namespacesString = JSON.stringify(res.body);
@@ -600,23 +600,6 @@ export class KubernetesObj extends KubernetesContext {
         }
         return undefined;
       });
-
-    // const namespaceList: Array<string> = [];
-
-    // const response = await this.coreV1Api?.listNamespace(undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, 5000);
-    // if (response?.response.statusCode === 200) {
-    //   let namespacesString = JSON.stringify(response.body);
-    //   let namespacesbjectList: ObjectList = JSON.parse(namespacesString);
-    //   for (const namespaces of namespacesbjectList.items) {
-    //     namespaceList.push(namespaces.metadata.name);
-    //   }
-    //   return namespaceList;
-    // } else if (response?.response.statusCode !== 403 && response?.response.statusCode !== 401) {
-    //   const msg = `Failure retrieving Namespace list: ${JSON.stringify(response?.response.errored?.message)}`;
-    //   console.error(msg);
-    // } else {
-    //   return undefined;
-    // }
   }
 
   /**

--- a/src/kubernetes/kubernetes.ts
+++ b/src/kubernetes/kubernetes.ts
@@ -579,7 +579,7 @@ export class KubernetesObj extends KubernetesContext {
   public async getNamespaceList(): Promise<string[] | undefined> {
     const namespaceList: Array<string> = [];
     return this.coreV1Api
-      ?.listNamespace()
+      ?.listNamespace(undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, 5)
       .then(res => {
         if (res.response.statusCode === 200) {
           let namespacesString = JSON.stringify(res.body);
@@ -600,6 +600,23 @@ export class KubernetesObj extends KubernetesContext {
         }
         return undefined;
       });
+
+    // const namespaceList: Array<string> = [];
+
+    // const response = await this.coreV1Api?.listNamespace(undefined, undefined, undefined, undefined, undefined, undefined, undefined, undefined, 5000);
+    // if (response?.response.statusCode === 200) {
+    //   let namespacesString = JSON.stringify(response.body);
+    //   let namespacesbjectList: ObjectList = JSON.parse(namespacesString);
+    //   for (const namespaces of namespacesbjectList.items) {
+    //     namespaceList.push(namespaces.metadata.name);
+    //   }
+    //   return namespaceList;
+    // } else if (response?.response.statusCode !== 403 && response?.response.statusCode !== 401) {
+    //   const msg = `Failure retrieving Namespace list: ${JSON.stringify(response?.response.errored?.message)}`;
+    //   console.error(msg);
+    // } else {
+    //   return undefined;
+    // }
   }
 
   /**

--- a/src/shellCommands/ocSdkCommands.ts
+++ b/src/shellCommands/ocSdkCommands.ts
@@ -339,10 +339,11 @@ export class OcSdkCommand {
           const playbookTasksFailures = commandOutput.match(playbookTasksFailureRegex);
           const finalFailureObject = playbookTasksFailures?.[playbookTasksFailures.length - 1]?.replace("FAILED! => ", "");
           if (finalFailureObject) {
-            const error = `(RC: ${returnCode}) ${JSON.parse(finalFailureObject)?.["msg"]}`;
-            reject(error);
+            const errorMessage = `(RC: ${returnCode}) ${JSON.parse(finalFailureObject)?.["msg"]}`;
+            reject(errorMessage);
           } else {
-            reject(commandOutput);
+            const errorMessage = `(RC: ${returnCode}) ${commandOutput}`;
+            reject(errorMessage);
           }
         });
     });

--- a/src/shellCommands/ocSdkCommands.ts
+++ b/src/shellCommands/ocSdkCommands.ts
@@ -174,7 +174,6 @@ export class OcSdkCommand {
    */
   async runOcSdkVersion(outputChannel?: vscode.OutputChannel, logPath?: string): Promise<string | undefined> {
     const galaxyNamespace = getAnsibleGalaxySettings(AnsibleGalaxySettings.ansibleGalaxyNamespace) as string;
-    let versionInstalled: string;
 
     // ansible-galaxy collection list | grep ibm.operator_collection_sdk
     const cmd: string = "ansible-galaxy";
@@ -182,7 +181,7 @@ export class OcSdkCommand {
 
     return this.run(cmd, args, outputChannel, logPath)
       .then(() => {
-        versionInstalled = this.commandOutput.split(" ")?.filter(item => {
+        const versionInstalled = this.commandOutput.split(" ")?.filter(item => {
           return item.length;
         })?.[1]; // item in [1] is the version
         return versionInstalled;


### PR DESCRIPTION
Fix for issue #36. Display last task failure message for `executeSimpleCommand` by fetching the last task failure in playbook executed as opposed to simply displaying the return code. The previous method displayed errors like this `"Failure executing Redeploy Operator command: RC 2"`

The new method displays failure information, if it exists. Example:
<img width="564" alt="Screenshot 2024-01-18 at 10 38 32 AM" src="https://github.com/IBM/operator-collection-sdk-vscode-extension/assets/91276489/37394df1-b519-4c2d-a072-8a33c602870a">


